### PR TITLE
Display challenge data along with renaming function & variable names

### DIFF
--- a/evalai/challenges.py
+++ b/evalai/challenges.py
@@ -1,5 +1,4 @@
 import click
-from click import echo
 
 from evalai.utils.challenges import (
                                     get_challenge_list,
@@ -11,26 +10,14 @@ from evalai.utils.challenges import (
 
 @click.group(invoke_without_command=True)
 @click.pass_context
-def challenges(ctx):
-    """
-    Challenges and related options.
-    """
-    if ctx.invoked_subcommand is None:
-        welcome_text = ("Welcome to the EvalAI CLI. Use evalai"
-                        "challenges --help for viewing all the options.")
-        echo(welcome_text)
-
-
-@click.group(invoke_without_command=True, name='list')
-@click.pass_context
 @click.option('--participant', is_flag=True,
-              help="Show the challenges that you've participated")
+              help="List the challenges that you've participated")
 @click.option('--host', is_flag=True,
-              help="Show the challenges that you've hosted")
-def list_challenges(ctx, participant, host):
+              help="List the challenges that you've hosted")
+def challenges(ctx, participant, host):
     """
-    Used to list challenges.
-    Invoked by running `evalai challenges list`
+    Lists challenges.
+    Invoked by running `evalai challenges`
     """
     if participant or host:
         get_participated_or_hosted_challenges(host, participant)
@@ -38,37 +25,28 @@ def list_challenges(ctx, participant, host):
         get_challenge_list()
 
 
-@click.command(name='ongoing')
-def list_ongoing_challenges():
+@challenges.command()
+def ongoing():
     """
-    Used to list all the challenges which are active.
-    Invoked by running `evalai challenges list ongoing`
+    List all active challenges.
+    Invoked by running `evalai challenges ongoing`
     """
     get_ongoing_challenge_list()
 
 
-@click.command(name='past')
-def list_past_challenges():
+@challenges.command()
+def past():
     """
-    Used to list all the past challenges.
-    Invoked by running `evalai challenges list past`
+    List all past challenges.
+    Invoked by running `evalai challenges past`
     """
     get_past_challenge_list()
 
 
-@click.command(name='future')
-def list_future_challenges():
+@challenges.command()
+def future():
     """
-    Used to list all the challenges which are coming up.
-    Invoked by running `evalai challenges list future`
+    List all upcoming challenges.
+    Invoked by running `evalai challenges future`
     """
     get_future_challenge_list()
-
-
-# Command -> evalai challenges list
-challenges.add_command(list_challenges)
-
-# Command -> evalai challenges list ongoing/past/future
-list_challenges.add_command(list_ongoing_challenges)
-list_challenges.add_command(list_past_challenges)
-list_challenges.add_command(list_future_challenges)

--- a/evalai/challenges.py
+++ b/evalai/challenges.py
@@ -1,11 +1,11 @@
 import click
 
 from evalai.utils.challenges import (
-                                    get_challenge_list,
-                                    get_ongoing_challenge_list,
-                                    get_past_challenge_list,
-                                    get_future_challenge_list,
-                                    get_participated_or_hosted_challenges,)
+                                    display_participated_or_hosted_challenges,
+                                    display_all_challenge_list,
+                                    display_future_challenge_list,
+                                    display_ongoing_challenge_list,
+                                    display_past_challenge_list,)
 
 
 @click.group(invoke_without_command=True)
@@ -16,37 +16,41 @@ from evalai.utils.challenges import (
               help="List the challenges that you've hosted")
 def challenges(ctx, participant, host):
     """
-    Lists challenges.
+    Lists challenges
+
     Invoked by running `evalai challenges`
     """
     if participant or host:
-        get_participated_or_hosted_challenges(host, participant)
+        display_participated_or_hosted_challenges(host, participant)
     elif ctx.invoked_subcommand is None:
-        get_challenge_list()
+        display_all_challenge_list()
 
 
 @challenges.command()
 def ongoing():
     """
-    List all active challenges.
+    List all active challenges
+
     Invoked by running `evalai challenges ongoing`
     """
-    get_ongoing_challenge_list()
+    display_ongoing_challenge_list()
 
 
 @challenges.command()
 def past():
     """
-    List all past challenges.
+    List all past challenges
+
     Invoked by running `evalai challenges past`
     """
-    get_past_challenge_list()
+    display_past_challenge_list()
 
 
 @challenges.command()
 def future():
     """
-    List all upcoming challenges.
+    List all upcoming challenges
+
     Invoked by running `evalai challenges future`
     """
-    get_future_challenge_list()
+    display_future_challenge_list()

--- a/evalai/challenges.py
+++ b/evalai/challenges.py
@@ -1,11 +1,11 @@
 import click
 
 from evalai.utils.challenges import (
-                                    display_participated_or_hosted_challenges,
                                     display_all_challenge_list,
                                     display_future_challenge_list,
                                     display_ongoing_challenge_list,
-                                    display_past_challenge_list,)
+                                    display_past_challenge_list,
+                                    display_participated_or_hosted_challenges,)
 
 
 @click.group(invoke_without_command=True)

--- a/evalai/challenges.py
+++ b/evalai/challenges.py
@@ -6,7 +6,7 @@ from evalai.utils.challenges import (
                                     get_ongoing_challenge_list,
                                     get_past_challenge_list,
                                     get_future_challenge_list,
-                                    get_challenge_count,)
+                                    get_participated_or_hosted_challenges,)
 
 
 @click.group(invoke_without_command=True)
@@ -32,10 +32,8 @@ def list_challenges(ctx, participant, host):
     Used to list challenges.
     Invoked by running `evalai challenges list`
     """
-    if participant:
-        get_challenge_count(host, participant)
-    elif host:
-        get_challenge_count(host, participant)
+    if participant or host:
+        get_participated_or_hosted_challenges(host, participant)
     elif ctx.invoked_subcommand is None:
         get_challenge_list()
 

--- a/evalai/utils/auth.py
+++ b/evalai/utils/auth.py
@@ -5,7 +5,7 @@ from click import echo
 from evalai.utils.config import AUTH_TOKEN_PATH
 
 
-def get_token():
+def get_user_auth_token():
     """
     Loads token to be used for sending requests.
     """
@@ -24,12 +24,12 @@ def get_token():
         return None
 
 
-def get_headers():
+def get_request_header():
     """
-    Returns token formatted in header for sending requests.
+    Returns user auth token formatted in header for sending requests.
     """
-    headers = {
-            "Authorization": "Token {}".format(get_token()),
+    header = {
+            "Authorization": "Token {}".format(get_user_auth_token()),
     }
 
-    return headers
+    return header

--- a/evalai/utils/challenges.py
+++ b/evalai/utils/challenges.py
@@ -1,15 +1,19 @@
+import os
 import requests
 import sys
 
 from click import echo, style
 
-from evalai.utils.auth import get_headers
-from evalai.utils.common import valid_token
+from evalai.utils.auth import get_request_header
+from evalai.utils.common import validate_token
 from evalai.utils.urls import URLS
 from evalai.utils.config import API_HOST_URL
 
 
-def print_challenge_table(challenge):
+def pretty_print_challenge_data(challenge):
+    """
+    Function to print the challenge data
+    """
     br = style("----------------------------------------"
                "--------------------------", bold=True)
 
@@ -21,17 +25,21 @@ def print_challenge_table(challenge):
     title = "{} {}".format(challenge_title, challenge_id)
 
     description = "{}\n".format(challenge["short_description"])
-    date = "End Date : " + style(challenge["end_date"].split("T")[0], fg="red")
-    date = "\n{}\n\n".format(style(date, bold=True))
-    challenge = "{}{}{}{}".format(title, description, date, br)
+    end_date = "End Date : " + style(challenge["end_date"].split("T")[0], fg="red")
+    end_date = "\n{}\n\n".format(style(end_date, bold=True))
+    challenge = "{}{}{}{}".format(title, description, end_date, br)
     echo(challenge)
 
 
-def get_challenges(url):
+def display_challenges(url):
 
-    headers = get_headers()
+    """
+    Function to fetch & display the challenge list based on API
+    """
+
+    header = get_request_header()
     try:
-        response = requests.get(url, headers=headers)
+        response = requests.get(url, headers=header)
         response.raise_for_status()
     except requests.exceptions.HTTPError as err:
         echo(err)
@@ -40,57 +48,57 @@ def get_challenges(url):
         echo(err)
         sys.exit(1)
 
-    response_json = response.json()
-    if valid_token(response_json):
+    response = response.json()
+    if validate_token(response):
 
-        challenges = response_json["results"]
+        challenges = response["results"]
         if len(challenges) is not 0:
             for challenge in challenges:
-                print_challenge_table(challenge)
+                pretty_print_challenge_data(challenge)
         else:
-            echo("Sorry, no challenges found.")
+            echo("Sorry, no challenges found!")
 
 
-def get_challenge_list():
+def display_all_challenge_list():
     """
-    Fetches the list of challenges from the backend.
+    Displays the list of all challenges from the backend
     """
     url = "{}{}".format(API_HOST_URL, URLS.challenge_list.value)
-    get_challenges(url)
+    display_challenges(url)
 
 
-def get_past_challenge_list():
+def display_past_challenge_list():
     """
-    Fetches the list of past challenges from the backend.
+    Displays the list of past challenges from the backend
     """
     url = "{}{}".format(API_HOST_URL, URLS.past_challenge_list.value)
-    get_challenges(url)
+    display_challenges(url)
 
 
-def get_ongoing_challenge_list():
+def display_ongoing_challenge_list():
     """
-    Fetches the list of ongoing challenges from the backend.
+    Displays the list of ongoing challenges from the backend
     """
     url = "{}{}".format(API_HOST_URL, URLS.challenge_list.value)
-    get_challenges(url)
+    display_challenges(url)
 
 
-def get_future_challenge_list():
+def display_future_challenge_list():
     """
-    Fetches the list of future challenges from the backend.
+    Displays the list of future challenges from the backend
     """
     url = "{}{}".format(API_HOST_URL, URLS.future_challenge_list.value)
-    get_challenges(url)
+    display_challenges(url)
 
 
-def get_teams(url):
+def get_partcipant_or_host_teams(url):
     """
-    Returns the teams corresponding to the user.
+    Returns the participant or host teams corresponding to the user
     """
-    headers = get_headers()
+    header = get_request_header()
 
     try:
-        response = requests.get(url, headers=headers)
+        response = requests.get(url, headers=header)
         response.raise_for_status()
     except requests.exceptions.HTTPError as err:
         echo(err)
@@ -99,24 +107,24 @@ def get_teams(url):
         echo(err)
         sys.exit(1)
 
-    response_json = response.json()
+    response = response.json()
 
-    if valid_token(response_json):
-        return response_json['results']
+    if validate_token(response):
+        return response['results']
     else:
-        echo("The token is not valid. Try again.")
+        echo("The authentication token is not valid. Please try again!")
         sys.exit(1)
 
 
-def get_teams_challenges(url, teams):
+def get_participant_or_host_team_challenges(url, teams):
     """
-    Returns the challenges corresponding to the teams.
+    Returns the challenges corresponding to the participant or host teams
     """
     challenges = []
     for team in teams:
-        headers = get_headers()
+        header = get_request_header()
         try:
-            response = requests.get(url.format(team['id']), headers=headers)
+            response = requests.get(url.format(team['id']), headers=header)
             response.raise_for_status()
         except requests.exceptions.HTTPError as err:
             echo(err)
@@ -124,45 +132,38 @@ def get_teams_challenges(url, teams):
         except requests.exceptions.RequestException as err:
             echo(err)
             sys.exit(1)
-        response_json = response.json()
-        challenges = challenges + response_json['results']
+        response = response.json()
+        challenges += response['results']
     return challenges
 
 
-def get_participated_or_hosted_challenges(is_host=False, is_participant=False):
+def display_participated_or_hosted_challenges(is_host=False, is_participant=False):
     """
-    Function to display the participated or hosted challenges by a user.
+    Function to display the participated or hosted challenges by a user
     """
+
+    challenges = []
+
     if is_host:
-        challenges = []
         team_url = "{}{}".format(API_HOST_URL,
                                  URLS.host_teams.value)
         challenge_url = "{}{}".format(API_HOST_URL,
                                       URLS.host_challenges.value)
-        teams = get_teams(team_url)
-
-        challenges = get_teams_challenges(challenge_url, teams)
-
-        echo(style("\nHosted Challenges.\n", bold=True, bg="blue"))
-        if len(challenges) != 0:
-            for challenge in challenges:
-                print_challenge_table(challenge)
-        else:
-            echo("Sorry, no you haven't hosted any challenges.\n")
+        echo(style("\nHosted Challenges\n", bold=True))
 
     if is_participant:
-        challenges = []
         team_url = "{}{}".format(API_HOST_URL,
                                  URLS.participant_teams.value)
         challenge_url = "{}{}".format(API_HOST_URL,
                                       URLS.participant_challenges.value)
-        teams = get_teams(team_url)
+        echo(style("\nParticipated Challenges\n", bold=True))
 
-        challenges = get_teams_challenges(challenge_url, teams)
+    teams = get_partcipant_or_host_teams(team_url)
 
-        echo(style("\nParticipated Challenges.\n", bold=True, bg="blue"))
-        if len(challenges) != 0:
-            for challenge in challenges:
-                print_challenge_table(challenge)
-        else:
-            echo("Sorry, you haven't participated in any challenges.")
+    challenges = get_participant_or_host_team_challenges(challenge_url, teams)
+
+    if len(challenges) != 0:
+        for challenge in challenges:
+            pretty_print_challenge_data(challenge)
+    else:
+        echo("Sorry, no challenges found!")

--- a/evalai/utils/challenges.py
+++ b/evalai/utils/challenges.py
@@ -31,7 +31,6 @@ def pretty_print_challenge_data(challenge):
 
 
 def display_challenges(url):
-
     """
     Function to fetch & display the challenge list based on API
     """

--- a/evalai/utils/challenges.py
+++ b/evalai/utils/challenges.py
@@ -129,29 +129,40 @@ def get_teams_challenges(url, teams):
     return challenges
 
 
-def get_challenge_count(is_host=False, is_participant=False):
+def get_participated_or_hosted_challenges(is_host=False, is_participant=False):
     """
-    Gets the challenge the user has participated or hosted.
+    Function to display the participated or hosted challenges by a user.
     """
-    challenges = []
-
     if is_host:
+        challenges = []
         team_url = "{}{}".format(API_HOST_URL,
                                  URLS.host_teams.value)
         challenge_url = "{}{}".format(API_HOST_URL,
                                       URLS.host_challenges.value)
-    elif is_participant:
+        teams = get_teams(team_url)
+
+        challenges = get_teams_challenges(challenge_url, teams)
+
+        echo(style("\nHosted Challenges.\n", bold=True, bg="blue"))
+        if len(challenges) != 0:
+            for challenge in challenges:
+                print_challenge_table(challenge)
+        else:
+            echo("Sorry, no you haven't hosted any challenges.\n")
+
+    if is_participant:
+        challenges = []
         team_url = "{}{}".format(API_HOST_URL,
                                  URLS.participant_teams.value)
         challenge_url = "{}{}".format(API_HOST_URL,
                                       URLS.participant_challenges.value)
-    else:
-        echo("Option doesn't exist. Use --help for information")
-        sys.exit(1)
+        teams = get_teams(team_url)
 
-    teams = get_teams(team_url)
+        challenges = get_teams_challenges(challenge_url, teams)
 
-    challenges = get_teams_challenges(challenge_url, teams)
-
-    for challenge in challenges:
-        print_challenge_table(challenge)
+        echo(style("\nParticipated Challenges.\n", bold=True, bg="blue"))
+        if len(challenges) != 0:
+            for challenge in challenges:
+                print_challenge_table(challenge)
+        else:
+            echo("Sorry, you haven't participated in any challenges.")

--- a/evalai/utils/challenges.py
+++ b/evalai/utils/challenges.py
@@ -150,6 +150,16 @@ def display_participated_or_hosted_challenges(is_host=False, is_participant=Fals
                                       URLS.host_challenges.value)
         echo(style("\nHosted Challenges\n", bold=True))
 
+        teams = get_participant_or_host_teams(team_url)
+
+        challenges = get_participant_or_host_team_challenges(challenge_url, teams)
+
+        if len(challenges) != 0:
+            for challenge in challenges:
+                pretty_print_challenge_data(challenge)
+        else:
+            echo("Sorry, no challenges found!")
+
     if is_participant:
         team_url = "{}{}".format(API_HOST_URL,
                                  URLS.participant_teams.value)
@@ -157,12 +167,12 @@ def display_participated_or_hosted_challenges(is_host=False, is_participant=Fals
                                       URLS.participant_challenges.value)
         echo(style("\nParticipated Challenges\n", bold=True))
 
-    teams = get_participant_or_host_teams(team_url)
+        teams = get_participant_or_host_teams(team_url)
 
-    challenges = get_participant_or_host_team_challenges(challenge_url, teams)
+        challenges = get_participant_or_host_team_challenges(challenge_url, teams)
 
-    if len(challenges) != 0:
-        for challenge in challenges:
-            pretty_print_challenge_data(challenge)
-    else:
-        echo("Sorry, no challenges found!")
+        if len(challenges) != 0:
+            for challenge in challenges:
+                pretty_print_challenge_data(challenge)
+        else:
+            echo("Sorry, no challenges found!")

--- a/evalai/utils/challenges.py
+++ b/evalai/utils/challenges.py
@@ -90,7 +90,7 @@ def display_future_challenge_list():
     display_challenges(url)
 
 
-def get_partcipant_or_host_teams(url):
+def get_participant_or_host_teams(url):
     """
     Returns the participant or host teams corresponding to the user
     """

--- a/evalai/utils/challenges.py
+++ b/evalai/utils/challenges.py
@@ -1,4 +1,3 @@
-import os
 import requests
 import sys
 

--- a/evalai/utils/challenges.py
+++ b/evalai/utils/challenges.py
@@ -157,7 +157,7 @@ def display_participated_or_hosted_challenges(is_host=False, is_participant=Fals
                                       URLS.participant_challenges.value)
         echo(style("\nParticipated Challenges\n", bold=True))
 
-    teams = get_partcipant_or_host_teams(team_url)
+    teams = get_participant_or_host_teams(team_url)
 
     challenges = get_participant_or_host_team_challenges(challenge_url, teams)
 

--- a/evalai/utils/common.py
+++ b/evalai/utils/common.py
@@ -1,9 +1,9 @@
 from click import echo
 
 
-def valid_token(response):
+def validate_token(response):
     """
-    Checks if token is valid.
+    Function to check if the authentication token provided by user is valid or not.
     """
 
     if ('detail' in response):

--- a/tests/data/challenge_response.py
+++ b/tests/data/challenge_response.py
@@ -1,6 +1,6 @@
 challenges = """
                 {
-                    "count": 10,
+                    "count": 2,
                     "next": null,
                     "previous": null,
                     "results": [
@@ -80,7 +80,7 @@ challenges = """
 
 challenge_participant_teams = """
                 {
-                    "count": 2,
+                    "count": 1,
                     "next": null,
                     "previous": null,
                     "results": [

--- a/tests/test_challenges.py
+++ b/tests/test_challenges.py
@@ -54,28 +54,28 @@ class TestChallenges(BaseTestClass):
     @responses.activate
     def test_challenge_lists(self):
         runner = CliRunner()
-        result = runner.invoke(challenges, ['list'])
+        result = runner.invoke(challenges)
         response_table = result.output
         assert response_table == self.output
 
     @responses.activate
     def test_challenge_lists_past(self):
         runner = CliRunner()
-        result = runner.invoke(challenges, ['list', 'past'])
+        result = runner.invoke(challenges, ['past'])
         response_table = result.output
         assert response_table == self.output
 
     @responses.activate
     def test_challenge_lists_ongoing(self):
         runner = CliRunner()
-        result = runner.invoke(challenges, ['list', 'ongoing'])
+        result = runner.invoke(challenges, ['ongoing'])
         response_table = result.output
         assert response_table == self.output
 
     @responses.activate
     def test_challenge_lists_future(self):
         runner = CliRunner()
-        result = runner.invoke(challenges, ['list', 'future'])
+        result = runner.invoke(challenges, ['future'])
         response_table = result.output
         assert response_table == self.output
 

--- a/tests/test_challenges.py
+++ b/tests/test_challenges.py
@@ -15,22 +15,22 @@ class TestChallenges(BaseTestClass):
 
     def setup(self):
 
-        json_data = json.loads(challenge_response.challenges)
+        challenge_data = json.loads(challenge_response.challenges)
 
         url = "{}{}"
         responses.add(responses.GET, url.format(API_HOST_URL, URLS.challenge_list.value),
-                      json=json_data, status=200)
+                      json=challenge_data, status=200)
 
         responses.add(responses.GET, url.format(API_HOST_URL, URLS.past_challenge_list.value),
-                      json=json_data, status=200)
+                      json=challenge_data, status=200)
 
         responses.add(responses.GET, url.format(API_HOST_URL, URLS.challenge_list.value),
-                      json=json_data, status=200)
+                      json=challenge_data, status=200)
 
         responses.add(responses.GET, url.format(API_HOST_URL, URLS.future_challenge_list.value),
-                      json=json_data, status=200)
+                      json=challenge_data, status=200)
 
-        challenges = json_data["results"]
+        challenges = challenge_data["results"]
 
         self.output = ""
 
@@ -45,9 +45,9 @@ class TestChallenges(BaseTestClass):
 
             heading = "{} {}".format(challenge_title, challenge_id)
             description = "{}\n".format(challenge["short_description"])
-            end_date = "End Date : " + challenge["end_date"].split("T")[0]
-            end_date = subtitle.format(end_date)
-            challenge = "{}{}{}{}".format(heading, description, end_date, br)
+            challenge_end_date = "End Date : " + challenge["end_date"].split("T")[0]
+            challenge_end_date = subtitle.format(challenge_end_date)
+            challenge = "{}{}{}{}".format(heading, description, challenge_end_date, br)
 
             self.output = "{}{}".format(self.output, challenge)
 
@@ -59,28 +59,28 @@ class TestChallenges(BaseTestClass):
         assert response_table == self.output
 
     @responses.activate
-    def test_challenge_lists_past(self):
+    def test_past_challenge_lists(self):
         runner = CliRunner()
         result = runner.invoke(challenges, ['past'])
         response_table = result.output
         assert response_table == self.output
 
     @responses.activate
-    def test_challenge_lists_ongoing(self):
+    def test_ongoing_challenge_lists(self):
         runner = CliRunner()
         result = runner.invoke(challenges, ['ongoing'])
         response_table = result.output
         assert response_table == self.output
 
     @responses.activate
-    def test_challenge_lists_future(self):
+    def test_future_challenge_lists(self):
         runner = CliRunner()
         result = runner.invoke(challenges, ['future'])
         response_table = result.output
         assert response_table == self.output
 
 
-class TestTeamChallenges(BaseTestClass):
+class TestParticipantOrHostTeamChallenges(BaseTestClass):
 
     def setup(self):
 
@@ -116,24 +116,26 @@ class TestTeamChallenges(BaseTestClass):
 
             heading = "{} {}".format(challenge_title, challenge_id)
             description = "{}\n".format(challenge["short_description"])
-            end_date = "End Date : " + challenge["end_date"].split("T")[0]
-            end_date = subtitle.format(end_date)
-            challenge = "{}{}{}{}".format(heading, description, end_date, br)
+            challenge_end_date = "End Date : " + challenge["end_date"].split("T")[0]
+            challenge_end_date = subtitle.format(challenge_end_date)
+            challenge = "{}{}{}{}".format(heading, description, challenge_end_date, br)
 
             self.output = "{}{}".format(self.output, challenge)
 
     @responses.activate
-    def test_challenge_lists_host(self):
+    def test_host_challenge_list(self):
         runner = CliRunner()
-        self.output = "\nHosted Challenges.\n\n" + self.output
-        result = runner.invoke(challenges, ['list', '--host'])
-        response_table = result.output
-        assert response_table == self.output
+        expected = "\nHosted Challenges\n\n"
+        self.output = "{}{}".format(expected, self.output)
+        result = runner.invoke(challenges, ['--host'])
+        response = result.output
+        assert response == self.output
 
     @responses.activate
-    def test_challenge_lists_participant(self):
+    def test_participant_challenge_lists(self):
         runner = CliRunner()
-        self.output = "\nParticipated Challenges.\n\n" + self.output
-        result = runner.invoke(challenges, ['list', '--participant'])
-        response_table = result.output
-        assert response_table == self.output
+        expected = "\nParticipated Challenges\n\n"
+        self.output = "{}{}".format(expected, self.output)
+        result = runner.invoke(challenges, ['--participant'])
+        response = result.output
+        assert response == self.output

--- a/tests/test_challenges.py
+++ b/tests/test_challenges.py
@@ -125,6 +125,7 @@ class TestTeamChallenges(BaseTestClass):
     @responses.activate
     def test_challenge_lists_host(self):
         runner = CliRunner()
+        self.output = "\nHosted Challenges.\n\n" + self.output
         result = runner.invoke(challenges, ['list', '--host'])
         response_table = result.output
         assert response_table == self.output
@@ -132,6 +133,7 @@ class TestTeamChallenges(BaseTestClass):
     @responses.activate
     def test_challenge_lists_participant(self):
         runner = CliRunner()
+        self.output = "\nParticipated Challenges.\n\n" + self.output
         result = runner.invoke(challenges, ['list', '--participant'])
         response_table = result.output
         assert response_table == self.output

--- a/tests/test_challenges.py
+++ b/tests/test_challenges.py
@@ -139,3 +139,13 @@ class TestParticipantOrHostTeamChallenges(BaseTestClass):
         result = runner.invoke(challenges, ['--participant'])
         response = result.output
         assert response == self.output
+
+    @responses.activate
+    def test_participant_and_host_challenge_lists(self):
+        runner = CliRunner()
+        participant_string = "\nParticipated Challenges\n\n"
+        host_string = "\nHosted Challenges\n\n"
+        self.output = "{}{}{}{}".format(host_string, self.output, participant_string, self.output)
+        result = runner.invoke(challenges, ['--participant', '--host'])
+        response = result.output
+        assert response == self.output


### PR DESCRIPTION
Fixes #25
Fixes #45 

The major changes that this PR takes into account is:

1. Add commands for displaying the past, ongoing, future, all challenge data.
2. Add commands for displaying the hosted & participated challenges by a user.
Commands: 
```

- evalai challenges
- evalai challenges ongoing
- evalai challenges past
- evalai challenges future
- evalai challenges --host
- evalai challenges --participant
- evalai challenges --host --participant

```
3. Modified the function names along with variables and removed the redundant code.