### PR TITLE
Add support for inputting submission metadata

### DIFF
--- a/evalai/challenges.py
+++ b/evalai/challenges.py
@@ -1,5 +1,7 @@
 import click
 
+from click import style
+
 from evalai.utils.challenges import (
                                     display_all_challenge_list,
                                     display_future_challenge_list,
@@ -185,7 +187,14 @@ def submit(ctx, file):
     """
     Invoked by running `evalai challenge CHALLENGE phase PHASE submit FILE`
     """
-    make_submission(ctx.challenge_id, ctx.phase_id, file)
+    submission_metadata = {}
+    if click.confirm('Do you want to include the Submission Details?'):
+        submission_metadata = {}
+        submission_metadata["method_name"] = click.prompt(style('Method Name', fg="yellow"), type=str)
+        submission_metadata["method_description"] = click.prompt(style('Method Description', fg="yellow"), type=str)
+        submission_metadata["project_url"] = click.prompt(style('Project URL', fg="yellow"), type=str)
+        submission_metadata["publication_url"] = click.prompt(style('Publication URL', fg="yellow"), type=str)
+    make_submission(ctx.challenge_id, ctx.phase_id, file, submission_metadata)
 
 
 challenge.add_command(phase)

--- a/evalai/utils/submissions.py
+++ b/evalai/utils/submissions.py
@@ -10,7 +10,7 @@ from evalai.utils.urls import URLS
 from evalai.utils.common import validate_token, convert_UTC_date_to_local
 
 
-def make_submission(challenge_id, phase_id, file):
+def make_submission(challenge_id, phase_id, file, submission_metadata={}):
     """
     Function to submit a file to a challenge
     """
@@ -21,8 +21,8 @@ def make_submission(challenge_id, phase_id, file):
     input_file = {'input_file': file}
     data = {
             'status': 'submitting',
+            **submission_metadata,
            }
-
     try:
         response = requests.post(
                                 url,

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -182,9 +182,10 @@ class TestHTTPErrorRequests(BaseTestClass):
             with open('test_file.txt', 'w') as f:
                 f.write('1 2 3 4 5 6')
 
-            result = runner.invoke(challenge, ['1', 'phase', '2', 'submit', "--file", "test_file.txt"])
+            result = runner.invoke(challenge, ['1', 'phase', '2', 'submit', "--file", "test_file.txt"], input="N")
             response = result.output.rstrip()
-            assert response == self.expected.format(url)
+            expected = "Do you want to include the Submission Details? [y/N]: N\n{}".format(self.expected.format(url))
+            assert response == expected
 
     @responses.activate
     def test_display_challenge_phase_split_list_for_http_error_404(self):
@@ -233,9 +234,10 @@ class TestSubmissionDetailsWhenObjectDoesNotExist(BaseTestClass):
             with open('test_file.txt', 'w') as f:
                 f.write('1 2 3 4 5 6')
 
-            result = runner.invoke(challenge, ['1', 'phase', '2', 'submit', "--file", "test_file.txt"])
+            result = runner.invoke(challenge, ['1', 'phase', '2', 'submit', "--file", "test_file.txt"], input="N")
             response = result.output.rstrip()
-            assert response == self.expected
+            expected = "Do you want to include the Submission Details? [y/N]: N\n{}".format(self.expected)
+            assert response == expected
 
 
 class TestTeamsWhenObjectDoesNotExist(BaseTestClass):
@@ -534,9 +536,10 @@ class TestRequestForExceptions(BaseTestClass):
             with open('test_file.txt', 'w') as f:
                 f.write('1 2 3 4 5 6')
 
-            result = runner.invoke(challenge, ['1', 'phase', '2', 'submit', "--file", "test_file.txt"])
-            response = result.output.strip()
-            assert response == "RequestException"
+            result = runner.invoke(challenge, ['1', 'phase', '2', 'submit', "--file", "test_file.txt"], input="N")
+            response = result.output.rstrip()
+            expected = "Do you want to include the Submission Details? [y/N]: N\n{}".format("RequestException")
+            assert response == expected
 
     @responses.activate
     def test_display_challenge_phase_split_list_for_request_exception(self):


### PR DESCRIPTION
```
(venv) isht3@Miller:~/evalai-cli$ evalai challenge 1 phase 2 submit README.md
Do you want to include the Submissions Metadata? [y/N]: N

Your file README.md with the ID 16 is successfully submitted.

You can use `evalai submission 16` to view this submission's status.
```

```
(venv) isht3@Miller:~/evalai-cli$ evalai challenge 1 phase 2 submit README.md
Do you want to include the Submissions Metadata? [y/N]: y
Method Name: test
Method Description: test
Project URL: test
Publication URL: test

Your file README.md with the ID 17 is successfully submitted.

You can use `evalai submission 17` to view this submission's status.
```
