### PR TITLE
add missing return statement

### DIFF
--- a/evalai/utils/common.py
+++ b/evalai/utils/common.py
@@ -65,5 +65,5 @@ def clean_data(data):
     Strip HTML and clean spaces
     """
     data = BeautifulSoup(data, "lxml").text.strip()
-    data = ' '.join(data.split())
-    data.encode("utf-8")
+    data = ' '.join(data.split()).encode("utf-8")
+    return data


### PR DESCRIPTION
> Noticed [this](https://github.com/Cloud-CV/evalai-cli/blob/5bc56718520c381f0e1710d9ece4fb2c5bc05449/evalai/utils/challenges.py#L233) function expects a return `data` which [this](https://github.com/Cloud-CV/evalai-cli/blob/5bc56718520c381f0e1710d9ece4fb2c5bc05449/evalai/utils/common.py#L69) function never returns 🙈

As per the discussion on [this](https://github.com/Cloud-CV/evalai-cli/pull/99#issuecomment-416816569) thread. I've added a `return` statement.

@RishabhJain2018 @isht3 please review 😄 