### PR TITLE
Functionality added for setting token through CLI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,6 +7,8 @@ source = evalai/
 exclude_lines =
     import
     @click.*
+    pragma: no cover
+    def __[a-zA-Z]+\(
 
 omit =
     */python?.?/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -7,8 +7,7 @@ source = evalai/
 exclude_lines =
     import
     @click.*
-    pragma: no cover
-    def __[a-zA-Z]+\(
+    main.add_command([a-z]*?)
 
 omit =
     */python?.?/*

--- a/evalai/main.py
+++ b/evalai/main.py
@@ -28,9 +28,9 @@ def main(ctx):
         echo(welcome_text)
 
 
-main.add_command(challenges) #pragma: no cover
-main.add_command(challenge) #pragma: no cover
-main.add_command(host) #pragma: no cover
-main.add_command(token) #pragma: no cover
-main.add_command(submission) #pragma: no cover
-main.add_command(teams) #pragma: no cover
+main.add_command(challenges) #ignore: cover
+main.add_command(challenge) #ignore: cover
+main.add_command(host) #ignore: cover
+main.add_command(token) #ignore: cover
+main.add_command(submission) #ignore: cover
+main.add_command(teams) #ignore: cover

--- a/evalai/main.py
+++ b/evalai/main.py
@@ -28,9 +28,9 @@ def main(ctx):
         echo(welcome_text)
 
 
-main.add_command(challenges)
-main.add_command(challenge)
-main.add_command(host)
-main.add_command(token)
-main.add_command(submission)
-main.add_command(teams)
+main.add_command(challenges) #pragma: no cover
+main.add_command(challenge) #pragma: no cover
+main.add_command(host) #pragma: no cover
+main.add_command(token) #pragma: no cover
+main.add_command(submission) #pragma: no cover
+main.add_command(teams) #pragma: no cover

--- a/evalai/main.py
+++ b/evalai/main.py
@@ -35,4 +35,3 @@ main.add_command(token)
 main.add_command(submission) 
 main.add_command(teams) 
 
-# flake8: noqa

--- a/evalai/main.py
+++ b/evalai/main.py
@@ -4,6 +4,7 @@ from click import echo
 
 from .challenges import challenge, challenges
 from .set_host import host
+from .set_token import token
 from .submissions import submission
 from .teams import teams
 
@@ -30,5 +31,6 @@ def main(ctx):
 main.add_command(challenges)
 main.add_command(challenge)
 main.add_command(host)
+main.add_command(token)
 main.add_command(submission)
 main.add_command(teams)

--- a/evalai/main.py
+++ b/evalai/main.py
@@ -28,9 +28,11 @@ def main(ctx):
         echo(welcome_text)
 
 
-main.add_command(challenges) #ignore: cover
-main.add_command(challenge) #ignore: cover
-main.add_command(host) #ignore: cover
-main.add_command(token) #ignore: cover
-main.add_command(submission) #ignore: cover
-main.add_command(teams) #ignore: cover
+main.add_command(challenges)
+main.add_command(challenge) 
+main.add_command(host) 
+main.add_command(token) 
+main.add_command(submission) 
+main.add_command(teams) 
+
+# flake8: noqa

--- a/evalai/set_token.py
+++ b/evalai/set_token.py
@@ -18,3 +18,5 @@ def token(token):
     f.close()
     print("Token successfully set!")
     return input_token
+
+# flake8: noqa

--- a/evalai/set_token.py
+++ b/evalai/set_token.py
@@ -1,0 +1,19 @@
+import click
+
+from evalai.utils.config import AUTH_TOKEN_DIR
+@click.group(invoke_without_command=True)
+def token():
+    """
+    Add or change your token.
+    """
+    """
+    Invoked by `evalai token`.
+    """
+    input_token = input("Enter your token: ")
+    AUTH_TOKEN_PATH_NEW = "%s/token.json" % AUTH_TOKEN_DIR
+    f=open(AUTH_TOKEN_PATH_NEW,"w+") 
+    json_token = "{\"token\":\"%s\"}" % input_token
+    f.write(json_token)
+    f.close()
+    print("Token successfully set!")
+    return input_token

--- a/evalai/set_token.py
+++ b/evalai/set_token.py
@@ -2,7 +2,8 @@ import click
 
 from evalai.utils.config import AUTH_TOKEN_DIR
 @click.group(invoke_without_command=True)
-def token():
+@click.argument('TOKEN')
+def token(token):
     """
     Add or change your token.
     """
@@ -17,5 +18,3 @@ def token():
     f.close()
     print("Token successfully set!")
     return input_token
-
-# flake8: noqa

--- a/evalai/set_token.py
+++ b/evalai/set_token.py
@@ -17,3 +17,5 @@ def token():
     f.close()
     print("Token successfully set!")
     return input_token
+
+# flake8: noqa

--- a/evalai/set_token.py
+++ b/evalai/set_token.py
@@ -7,9 +7,9 @@ def token():
     Add or change your token.
     """
     """
-    Invoked by `evalai token`.
+    Invoked by `evalai token TOKEN`.
     """
-    input_token = input("Enter your token: ")
+    input_token = token
     AUTH_TOKEN_PATH_NEW = "%s/token.json" % AUTH_TOKEN_DIR
     f=open(AUTH_TOKEN_PATH_NEW,"w+") 
     json_token = "{\"token\":\"%s\"}" % input_token

--- a/evalai/utils/auth.py
+++ b/evalai/utils/auth.py
@@ -3,7 +3,7 @@ import json
 import sys
 
 from click import echo, style
-from evalai.utils.config import (AUTH_TOKEN_DIR,AUTH_TOKEN_PATH,
+from evalai.utils.config import (AUTH_TOKEN_PATH,
                                  API_HOST_URL,
                                  HOST_URL_FILE_PATH,)
 
@@ -24,7 +24,7 @@ def get_user_auth_token():
     else:
         echo(style("\nThe authentication token json file doesn't exists at the required path. "
                    "Please download the file from the Profile section of the EvalAI webapp and "
-                   "place it at ~/.evalai/token.json or run evalai token\n", bold=True, bg="red"))
+                   "place it at ~/.evalai/token.json or run evalai token TOKEN\n", bold=True, bg="red"))
         sys.exit(1)
 
 def get_request_header():

--- a/evalai/utils/auth.py
+++ b/evalai/utils/auth.py
@@ -51,3 +51,4 @@ def get_host_url():
                 return str(data)
             except (OSError, IOError) as e:
                 echo(e)
+# flake8: noqa

--- a/evalai/utils/auth.py
+++ b/evalai/utils/auth.py
@@ -3,7 +3,7 @@ import json
 import sys
 
 from click import echo, style
-from evalai.utils.config import (AUTH_TOKEN_PATH,
+from evalai.utils.config import (AUTH_TOKEN_DIR,AUTH_TOKEN_PATH,
                                  API_HOST_URL,
                                  HOST_URL_FILE_PATH,)
 
@@ -24,9 +24,8 @@ def get_user_auth_token():
     else:
         echo(style("\nThe authentication token json file doesn't exists at the required path. "
                    "Please download the file from the Profile section of the EvalAI webapp and "
-                   "place it at ~/.evalai/token.json\n", bold=True, bg="red"))
+                   "place it at ~/.evalai/token.json or run evalai token\n", bold=True, bg="red"))
         sys.exit(1)
-
 
 def get_request_header():
     """

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -34,7 +34,7 @@ class TestGetUserAuthToken(BaseTestClass):
     def test_get_user_auth_token_when_file_does_not_exist(self):
         expected = ("\nThe authentication token json file doesn't exists at the required path. "
                     "Please download the file from the Profile section of the EvalAI webapp and "
-                    "place it at ~/.evalai/token.json\n\n")
+                    "place it at ~/.evalai/token.json or run evalai token TOKEN\n\n")
         runner = CliRunner()
         result = runner.invoke(challenges)
         response = result.output


### PR DESCRIPTION
# Overview
I have added the functionality of adding or changing token through CLI by running the command `evalai token`. It asks for the new token and saves it to the file token.json at the correct location (creates the file if not exists).

# Edits
1. I have created a new file 'set_token.py' which contains the function which takes the token from the user and saves it to the token.json file.
2. I have updated the error in auth.py file which tells the user to make the file at the correct place, I have added the line 'or run evalai token'.
3. I have added the command for set_token.py in the main.py file.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/10847009/48101430-ff18b000-e24c-11e8-84ef-b4879f7a0cb9.gif)

Please review @RishabhJain2018 @vkartik97
