### PR TITLE
GCI: Login in CLI using API Authentication Token String

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,6 +7,7 @@ source = evalai/
 exclude_lines =
     import
     @click.*
+    main.add_command([a-z]*?)
 
 omit =
     */python?.?/*

--- a/evalai/add_token.py
+++ b/evalai/add_token.py
@@ -1,0 +1,44 @@
+import click
+import os
+import validators
+
+from click import echo, style
+
+from evalai.utils.config import (AUTH_TOKEN_DIR,
+                                 AUTH_TOKEN_PATH,
+                                 LEN_OF_TOKEN,)
+
+
+@click.group(invoke_without_command=True)
+@click.argument('add_token')
+def token(add_token):
+    """
+    View and configure the EvalAI Token.
+    """
+    """
+    Invoked by `evalai token <your_token_here>`.
+    """
+    if add_token is not None:
+        if validators.length(add_token, min=LEN_OF_TOKEN, max=LEN_OF_TOKEN):
+            if not os.path.exists(AUTH_TOKEN_DIR):
+                os.makedirs(AUTH_TOKEN_DIR)
+            with open(AUTH_TOKEN_PATH, 'w+') as fw:
+                try:
+                    fw.write(add_token)
+                except (OSError, IOError) as e:
+                    echo(e)
+                echo(style("Token successfully set!", bold=True))
+        else:
+            echo(style("Error: Invalid Length. Enter a valid token of length: {}".format(LEN_OF_TOKEN), bold=True))
+    else:
+        if not os.path.exists(AUTH_TOKEN_PATH):
+            echo(style("\nThe authentication token json file doesn't exist at the required path. "
+                       "Please download the file from the Profile section of the EvalAI webapp and "
+                       "place it at ~/.evalai/token.json or use evalai -t <token> to add it.\n\n", bold=True))
+        else:
+            with open(AUTH_TOKEN_PATH, 'r') as fr:
+                try:
+                    data = fr.read()
+                    echo(style("Current token: {}".format(data), bold=True))
+                except (OSError, IOError) as e:
+                    echo(e)

--- a/evalai/main.py
+++ b/evalai/main.py
@@ -4,6 +4,7 @@ from click import echo
 
 from .challenges import challenge, challenges
 from .set_host import host
+from .add_token import token
 from .submissions import submission
 from .teams import teams
 
@@ -30,5 +31,6 @@ def main(ctx):
 main.add_command(challenges)
 main.add_command(challenge)
 main.add_command(host)
+main.add_command(token)
 main.add_command(submission)
 main.add_command(teams)

--- a/evalai/utils/config.py
+++ b/evalai/utils/config.py
@@ -4,6 +4,8 @@ import os
 from os.path import expanduser
 
 
+LEN_OF_TOKEN = 40
+
 AUTH_TOKEN_FILE_NAME = 'token.json'
 
 HOST_URL_FILE_NAME = 'host_url'


### PR DESCRIPTION
## What is this PR about?
GCI Task: Login in CLI using API Authentication Token String

## Features:
 - Adds a `token` argument that can be used to save the EvalAI token.
 - Validates the token and checks whether the token is of the right length.
 - Tokens can be added or updated using the `$ evalai token <your_token>` command

## Screenshots:
![add_token](https://user-images.githubusercontent.com/44368997/48277001-6f068080-e46f-11e8-8971-ce1a6fe0f7b9.gif)

## Reviewers:
Please review @RishabhJain2018 @vkartik97