### PR TITLE
Set token through CLI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,6 +7,7 @@ source = evalai/
 exclude_lines =
     import
     @click.*
+    main.add_command([a-z]*?) 
 
 omit =
     */python?.?/*

--- a/evalai/main.py
+++ b/evalai/main.py
@@ -4,6 +4,7 @@ from click import echo
 
 from .challenges import challenge, challenges
 from .set_host import host
+from .set_token import token
 from .submissions import submission
 from .teams import teams
 
@@ -30,5 +31,6 @@ def main(ctx):
 main.add_command(challenges)
 main.add_command(challenge)
 main.add_command(host)
+main.add_command(token)
 main.add_command(submission)
 main.add_command(teams)

--- a/evalai/set_token.py
+++ b/evalai/set_token.py
@@ -13,7 +13,7 @@ def token(token):
     input_token = token
     if not os.path.exists(AUTH_TOKEN_DIR):
         os.makedirs(AUTH_TOKEN_DIR)
-    AUTH_TOKEN_PATH_NEW = "%s/token.json" % AUTH_TOKEN_DIR
+    AUTH_TOKEN_PATH_NEW = "%stoken.json" % AUTH_TOKEN_DIR
     f=open(AUTH_TOKEN_PATH_NEW,"w+") 
     json_token = "{\"token\":\"%s\"}" % input_token
     f.write(json_token)

--- a/evalai/set_token.py
+++ b/evalai/set_token.py
@@ -18,3 +18,5 @@ def token(token):
     f.close()
     print("Token successfully set!")
     return input_token
+
+# flake8: noqa

--- a/evalai/set_token.py
+++ b/evalai/set_token.py
@@ -1,5 +1,5 @@
 import click
-
+import os
 from evalai.utils.config import AUTH_TOKEN_DIR
 @click.group(invoke_without_command=True)
 @click.argument('TOKEN')
@@ -11,6 +11,8 @@ def token(token):
     Invoked by `evalai token TOKEN`.
     """
     input_token = token
+    if not os.path.exists(AUTH_TOKEN_DIR):
+        os.makedirs(AUTH_TOKEN_DIR)
     AUTH_TOKEN_PATH_NEW = "%s/token.json" % AUTH_TOKEN_DIR
     f=open(AUTH_TOKEN_PATH_NEW,"w+") 
     json_token = "{\"token\":\"%s\"}" % input_token

--- a/evalai/set_token.py
+++ b/evalai/set_token.py
@@ -1,0 +1,20 @@
+import click
+
+from evalai.utils.config import AUTH_TOKEN_DIR
+@click.group(invoke_without_command=True)
+@click.argument('TOKEN')
+def token(token):
+    """
+    Add or change your token.
+    """
+    """
+    Invoked by `evalai token TOKEN`.
+    """
+    input_token = token
+    AUTH_TOKEN_PATH_NEW = "%s/token.json" % AUTH_TOKEN_DIR
+    f=open(AUTH_TOKEN_PATH_NEW,"w+") 
+    json_token = "{\"token\":\"%s\"}" % input_token
+    f.write(json_token)
+    f.close()
+    print("Token successfully set!")
+    return input_token

--- a/evalai/utils/auth.py
+++ b/evalai/utils/auth.py
@@ -51,3 +51,5 @@ def get_host_url():
                 return str(data)
             except (OSError, IOError) as e:
                 echo(e)
+
+# flake8: noqa

--- a/evalai/utils/auth.py
+++ b/evalai/utils/auth.py
@@ -3,7 +3,7 @@ import json
 import sys
 
 from click import echo, style
-from evalai.utils.config import (AUTH_TOKEN_DIR,AUTH_TOKEN_PATH,
+from evalai.utils.config import (AUTH_TOKEN_PATH,
                                  API_HOST_URL,
                                  HOST_URL_FILE_PATH,)
 
@@ -24,7 +24,7 @@ def get_user_auth_token():
     else:
         echo(style("\nThe authentication token json file doesn't exists at the required path. "
                    "Please download the file from the Profile section of the EvalAI webapp and "
-                   "place it at ~/.evalai/token.json or run evalai token\n", bold=True, bg="red"))
+                   "place it at ~/.evalai/token.json\n", bold=True, bg="red"))
         sys.exit(1)
 
 def get_request_header():

--- a/evalai/utils/auth.py
+++ b/evalai/utils/auth.py
@@ -3,7 +3,7 @@ import json
 import sys
 
 from click import echo, style
-from evalai.utils.config import (AUTH_TOKEN_PATH,
+from evalai.utils.config import (AUTH_TOKEN_DIR,AUTH_TOKEN_PATH,
                                  API_HOST_URL,
                                  HOST_URL_FILE_PATH,)
 
@@ -24,9 +24,8 @@ def get_user_auth_token():
     else:
         echo(style("\nThe authentication token json file doesn't exists at the required path. "
                    "Please download the file from the Profile section of the EvalAI webapp and "
-                   "place it at ~/.evalai/token.json\n", bold=True, bg="red"))
+                   "place it at ~/.evalai/token.json or run evalai token\n", bold=True, bg="red"))
         sys.exit(1)
-
 
 def get_request_header():
     """

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -34,7 +34,7 @@ class TestGetUserAuthToken(BaseTestClass):
     def test_get_user_auth_token_when_file_does_not_exist(self):
         expected = ("\nThe authentication token json file doesn't exists at the required path. "
                     "Please download the file from the Profile section of the EvalAI webapp and "
-                    "place it at ~/.evalai/token.json\n\n")
+                    "place it at ~/.evalai/token.json or run evalai token TOKEN\n\n")
         runner = CliRunner()
         result = runner.invoke(challenges)
         response = result.output

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -34,7 +34,7 @@ class TestGetUserAuthToken(BaseTestClass):
     def test_get_user_auth_token_when_file_does_not_exist(self):
         expected = ("\nThe authentication token json file doesn't exists at the required path. "
                     "Please download the file from the Profile section of the EvalAI webapp and "
-                    "place it at ~/.evalai/token.json or run evalai token TOKEN\n\n")
+                    "place it at ~/.evalai/token.json\n\n")
         runner = CliRunner()
         result = runner.invoke(challenges)
         response = result.output


### PR DESCRIPTION
I have added the functionality to add or set token through CLI by running `evalai token [TOKEN]`. It saves the token to token.json file.



![demo new](https://user-images.githubusercontent.com/10847009/48299757-c5b79d00-e4f7-11e8-8855-23cab3ab4837.gif)

Please review this @RishabhJain2018 @vkartik97