### PR TITLE
Added command for Logging into EvalAI using CLI

### DIFF
--- a/evalai/login.py
+++ b/evalai/login.py
@@ -10,7 +10,7 @@ from evalai.utils.config import AUTH_TOKEN_PATH, AUTH_TOKEN_DIR
 @click.group(invoke_without_command=True)
 @click.pass_context
 @click.argument("USERNAME", type=str)
-def login(ctx,username):
+def login(ctx, username):
     """
     Login to EvalAI and save token.
     """
@@ -33,4 +33,3 @@ def login(ctx,username):
                 echo(e)
 
     echo(style("\nLogged in successfully!", bold=True))
-

--- a/evalai/login.py
+++ b/evalai/login.py
@@ -1,0 +1,36 @@
+import click
+import os
+import json
+
+from click import echo, style
+from evalai.utils.auth import get_user_auth_token_by_login
+from evalai.utils.config import AUTH_TOKEN_PATH, AUTH_TOKEN_DIR
+
+
+@click.group(invoke_without_command=True)
+@click.pass_context
+@click.argument("USERNAME", type=str)
+def login(ctx,username):
+    """
+    Login to EvalAI and save token.
+    """
+    password = click.prompt("Enter password", type=str, hide_input=True)
+    token = get_user_auth_token_by_login(username, password)
+
+    if os.path.exists(AUTH_TOKEN_PATH):
+        with open(str(AUTH_TOKEN_PATH), "w") as TokenFile:
+            try:
+                json.dump(token, TokenFile)
+            except (OSError, IOError) as e:
+                echo(e)
+    else:
+        if not os.path.exists(AUTH_TOKEN_DIR):
+            os.makedirs(AUTH_TOKEN_DIR)
+        with open(str(AUTH_TOKEN_PATH), "w+") as TokenFile:
+            try:
+                json.dump(token, TokenFile)
+            except (OSError, IOError) as e:
+                echo(e)
+
+    echo(style("\nLogged in successfully!", bold=True))
+

--- a/evalai/login.py
+++ b/evalai/login.py
@@ -9,11 +9,11 @@ from evalai.utils.config import AUTH_TOKEN_PATH, AUTH_TOKEN_DIR
 
 @click.group(invoke_without_command=True)
 @click.pass_context
-@click.argument("USERNAME", type=str)
-def login(ctx, username):
+def login(ctx):
     """
     Login to EvalAI and save token.
     """
+    username = click.prompt("username", type=str, hide_input=False)
     password = click.prompt("Enter password", type=str, hide_input=True)
     token = get_user_auth_token_by_login(username, password)
 

--- a/evalai/login.py
+++ b/evalai/login.py
@@ -1,5 +1,5 @@
-import click
 import os
+import click
 import json
 
 from click import echo, style

--- a/evalai/main.py
+++ b/evalai/main.py
@@ -8,6 +8,7 @@ from .add_token import set_token
 from .submissions import submission
 from .teams import teams
 from .get_token import get_token
+from .login import login
 
 
 @click.group(invoke_without_command=True)
@@ -38,3 +39,4 @@ main.add_command(set_token)
 main.add_command(submission)
 main.add_command(teams)
 main.add_command(get_token)
+main.add_command(login)

--- a/evalai/utils/auth.py
+++ b/evalai/utils/auth.py
@@ -4,7 +4,10 @@ import sys
 import requests
 
 from click import echo, style
-from evalai.utils.config import AUTH_TOKEN_PATH, API_HOST_URL, HOST_URL_FILE_PATH
+from evalai.utils.config import (AUTH_TOKEN_PATH,
+                                 API_HOST_URL,
+                                 EVALAI_ERROR_CODES,
+                                 HOST_URL_FILE_PATH)
 from evalai.utils.urls import URLS
 
 
@@ -21,7 +24,7 @@ def get_user_auth_token_by_login(username, password):
         response = requests.post(url, data=payload)
         response.raise_for_status()
     except requests.exceptions.HTTPError as err:
-        if response.status_code == 400:
+        if response.status_code in EVALAI_ERROR_CODES:
             echo(
                 style(
                     "\nUnable to log in with provided credentials.\n",

--- a/evalai/utils/auth.py
+++ b/evalai/utils/auth.py
@@ -1,9 +1,48 @@
 import os
 import json
 import sys
+import requests
 
 from click import echo, style
 from evalai.utils.config import AUTH_TOKEN_PATH, API_HOST_URL, HOST_URL_FILE_PATH
+from evalai.utils.urls import URLS
+
+
+requests.packages.urllib3.disable_warnings()
+
+
+def get_user_auth_token_by_login(username, password):
+    """
+    Returns user auth token by login.
+    """
+    url = "{}{}".format(get_host_url(), URLS.login.value)
+    try:
+        payload = {'username': username, 'password': password}
+        response = requests.post(url, data=payload)
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as err:
+        if response.status_code == 400:
+            echo(
+                style(
+                    "\nUnable to log in with provided credentials.\n",
+                    bold=True,
+                    fg="red",
+                )
+            )
+        sys.exit(1)
+    except requests.exceptions.RequestException as err:
+        echo(
+            style(
+                "\nCould not establish a connection to EvalAI."
+                " Please check the Host URL.\n",
+                bold=True,
+                fg="red",
+            )
+        )
+        sys.exit(1)
+
+    token = response.json()
+    return token
 
 
 def get_user_auth_token():

--- a/evalai/utils/urls.py
+++ b/evalai/utils/urls.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 
 class URLS(Enum):
+    login = "/api/auth/login"
     challenge_list = "/api/challenges/challenge/all"
     past_challenge_list = "/api/challenges/challenge/past"
     future_challenge_list = "/api/challenges/challenge/future"


### PR DESCRIPTION
Fixes #137 
## Deliverables
* [x]  Add a command `evalai login <username>` which will prompt for the `password`.
* [x]  Once the password is entered, then the command will create a auth_token for the user by using the EvalAI login API, & saves it in the `token.json` file at `~/.evalai/token.json` in the user's system.
