### PR TITLE
Add badge for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Official Command Line utility to use EvalAI in your terminal.
 [![Join the chat at https://gitter.im/Cloud-CV/EvalAI](https://badges.gitter.im/Cloud-CV/EvalAI.svg)](https://gitter.im/Cloud-CV/EvalAI?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/Cloud-CV/evalai-cli.svg?branch=master)](https://travis-ci.org/Cloud-CV/evalai-cli)
 [![Coverage Status](https://coveralls.io/repos/github/Cloud-CV/evalai-cli/badge.svg?branch=master)](https://coveralls.io/github/Cloud-CV/evalai-cli?branch=master)
+[![Documentation Status](https://readthedocs.org/projects/markdown-guide/badge/?version=latest)](https://evalai-cli.cloudcv.org)
+
 
 ## Goal
 


### PR DESCRIPTION
Fixes #93 .
Updated ReadME with a badge for our new [docs](https://evalai-cli.cloudcv.org) page.
@RishabhJain2018 