### PR TITLE
Fix #119: Add command & feature for Creating challenge.

### DIFF
--- a/evalai/challenges.py
+++ b/evalai/challenges.py
@@ -76,6 +76,19 @@ def challenge(ctx, challenge):
         display_challenge_details(challenge)
 
 
+@challenges.command(context_settings={"ignore_unknown_options": True})
+@click.option("--file", type=click.File("rb"), required=True, help="Challenge Zip file.")
+@click.argument("team", type=int)
+def create(file, team):
+    """
+    Create challenge with Zip file & HostTeam ID.
+    """
+    """
+    Invoked by running 'evalai challenges create --file FILE TEAM'
+    """
+    create_challenge(file, team)
+
+
 @challenges.command()
 def ongoing():
     """

--- a/evalai/utils/challenges.py
+++ b/evalai/utils/challenges.py
@@ -21,6 +21,59 @@ from evalai.utils.urls import URLS
 requests.packages.urllib3.disable_warnings()
 
 
+def create_challenge(file, team):
+    """
+    Function to create a challenge.
+    """
+    url = "{}{}".format(get_host_url(), URLS.create_challenge.value)
+    url = url.format(team)
+
+    headers = get_request_header()
+    file = {"zip_configuration": file}
+
+    try:
+        response = requests.post(url, headers=headers, files=file)
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as err:
+        if response.status_code in EVALAI_ERROR_CODES:
+            validate_token(response.json())
+            echo(
+                style(
+                    "\nError: {}\n"
+                    "\nUse `evalai challenges` to fetch the active challenges.\n"
+                    "\nUse `evalai challenge CHALLENGE phases` to fetch the "
+                    "active phases.\n".format(response.json()["error"]),
+                    fg="red",
+                    bold=True,
+                )
+            )
+        else:
+            echo(err)
+        if "zip_configuration" in response.json():
+            echo(style(response.json()["zip_configuration"][0], fg="red", bold=True))
+        sys.exit(1)
+    except requests.exceptions.RequestException as err:
+        echo(
+            style(
+                "\nCould not establish a connection to EvalAI."
+                " Please check the Host URL.\n",
+                bold=True,
+                fg="red",
+            )
+        )
+        sys.exit(1)
+    response = response.json()
+    echo(
+        style(
+            "\n{}\n".format(
+                response["success"]
+            ),
+            fg="green",
+            bold=True,
+        )
+    )
+
+
 def pretty_print_challenge_data(challenges):
     """
     Function to print the challenge data

--- a/evalai/utils/urls.py
+++ b/evalai/utils/urls.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 
 class URLS(Enum):
+    create_challenge = "/api/challenges/challenge/challenge_host_team/{}/zip_upload/"
     login = "/api/auth/login"
     challenge_list = "/api/challenges/challenge/all"
     past_challenge_list = "/api/challenges/challenge/past"


### PR DESCRIPTION
Fixes #119 
Adds a subcommand to the `challenges` command to create the challenge using the Host team ID and a Zip file.
`evalai challenges create --file FILE TEAM` where FILE is the zip file and TEAM is the Host team ID.