### PR TITLE
Add command to display the submission result in terminal

### DIFF
--- a/evalai/submissions.py
+++ b/evalai/submissions.py
@@ -24,16 +24,37 @@ from evalai.utils.urls import URLS
 from evalai.utils.config import EVALAI_HOST_URLS, HOST_URL_FILE_PATH
 
 
+class Submission(object):
+
+    def __init__(self, submission_id):
+        self.submission_id = submission_id
+
+
 @click.group(invoke_without_command=True)
 @click.argument("SUBMISSION_ID", type=int)
-def submission(submission_id):
+@click.pass_context
+def submission(ctx, submission_id):
     """
     View submission specific details.
     """
     """
     Invoked by `evalai submission SUBMISSION_ID`.
     """
-    display_submission_details(submission_id)
+    ctx.obj = Submission(submission_id=submission_id)
+    if ctx.invoked_subcommand is None:
+        display_submission_details(submission_id)
+
+
+@submission.command()
+@click.pass_obj
+def result(ctx):
+    """
+    Display the submission result
+    """
+    """
+    Invoked by `evalai submission SUBMISSION_ID result`.
+    """
+    click.echo("Hello World!")
 
 
 @click.command()

--- a/evalai/submissions.py
+++ b/evalai/submissions.py
@@ -18,6 +18,7 @@ from evalai.utils.common import notify_user
 from evalai.utils.requests import make_request
 from evalai.utils.submissions import (
     display_submission_details,
+    display_submission_result,
     convert_bytes_to,
 )
 from evalai.utils.urls import URLS
@@ -54,7 +55,7 @@ def result(ctx):
     """
     Invoked by `evalai submission SUBMISSION_ID result`.
     """
-    click.echo("Hello World!")
+    display_submission_result(ctx.submission_id)
 
 
 @click.command()

--- a/evalai/utils/submissions.py
+++ b/evalai/utils/submissions.py
@@ -213,13 +213,12 @@ def pretty_print_submission_details(submission):
     echo(submission)
 
 
-def display_submission_details(submission_id):
+def submission_details_request(submission_id):
     """
-    Function to display details of a particular submission
+    Function to request details of a particular submission
     """
     url = "{}{}".format(get_host_url(), URLS.get_submission.value)
     url = url.format(submission_id)
-
     headers = get_request_header()
     try:
         response = requests.get(url, headers=headers)
@@ -251,9 +250,32 @@ def display_submission_details(submission_id):
             )
         )
         sys.exit(1)
-    response = response.json()
+    return response
 
+
+def display_submission_details(submission_id):
+    """
+    Function to display details of a particular submission
+    """
+    response = submission_details_request(submission_id).json()
     pretty_print_submission_details(response)
+
+
+def display_submission_result(submission_id):
+    """
+    Function to display result of a particular submission
+    """
+    try:
+        response = submission_details_request(submission_id).json()
+        echo(requests.get(response['submission_result_file']).text)
+    except requests.exceptions.MissingSchema:
+        echo(
+            style(
+                "\nThe Submission is yet to be evaluated.\n",
+                bold=True,
+                fg="yellow",
+            )
+        )
 
 
 def convert_bytes_to(byte, to, bsize=1024):

--- a/tests/data/submission_response.py
+++ b/tests/data/submission_response.py
@@ -118,7 +118,12 @@ submission_result = """
                     "status": "submitted",
                     "stderr_file": null,
                     "stdout_file": null,
-                    "submission_result_file": null,
+                    "submission_result_file": "http://testserver/media/submission_files/submission_9/result.json",
                     "submitted_at": "2018-06-08T09:24:09.866590Z",
                     "when_made_public": null
                 }"""
+
+
+submission_result_file = """
+                [{"Total": 60, "Metric1": 61, "Metric2": 62, "Metric3": 63}]
+                """

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -27,6 +27,13 @@ class TestGetSubmissionDetails(BaseTestClass):
             status=200,
         )
 
+        responses.add(
+            responses.GET,
+            self.submission["submission_result_file"],
+            json=json.loads(submission_response.submission_result_file),
+            status=200,
+        )
+
     @responses.activate
     def test_display_submission_details(self):
         team_title = "\n{}".format(self.submission["participant_team_name"])
@@ -79,6 +86,14 @@ class TestGetSubmissionDetails(BaseTestClass):
         runner = CliRunner()
         result = runner.invoke(submission)
         response = result.output
+        assert response == expected
+
+    @responses.activate
+    def test_display_submission_result(self):
+        expected = "{}\n".format(submission_response.submission_result_file).strip()
+        runner = CliRunner()
+        result = runner.invoke(submission, ["9", "result"])
+        response = result.output.strip()
         assert response == expected
 
 


### PR DESCRIPTION
Added command to display the submission result by passing the submission ID
Deliverables:
- [x] Added Command `$ evalai submission SUBMISSION_ID result`
- [x] Added supporting tests

Example:
```sh
$ evalai submission 12 result
↪ [{'Total': 60, 'Metric1': 61, 'Metric2': 62, 'Metric3': 63}]
```