### PR TITLE
Fix for enhancement#1001: Google Code-in Task to update the error message

### DIFF
--- a/evalai/submissions.py
+++ b/evalai/submissions.py
@@ -223,7 +223,9 @@ def download_file(url):
             echo(
                 style(
                     "\nCould not establish a connection to EvalAI."
-                    " Please check the Host URL.\n",
+                    " Please check the Host URL:{}.\n".format(
+                        signed_url
+                    ),
                     bold=True,
                     fg="red",
                 )

--- a/evalai/submissions.py
+++ b/evalai/submissions.py
@@ -223,8 +223,8 @@ def download_file(url):
             echo(
                 style(
                     "\nCould not establish a connection to EvalAI."
-                    " Please check the Host URL:{}.\n".format(
-                        signed_url
+                    " Please check the Host URL: {}\n".format(
+                        parsed_host_url
                     ),
                     bold=True,
                     fg="red",

--- a/evalai/utils/auth.py
+++ b/evalai/utils/auth.py
@@ -21,6 +21,7 @@ def get_user_auth_token_by_login(username, password):
     Returns user auth token by login.
     """
     url = "{}{}".format(get_host_url(), URLS.login.value)
+    host_url = get_host_url()
     try:
         payload = {"username": username, "password": password}
         response = requests.post(url, data=payload)
@@ -39,8 +40,8 @@ def get_user_auth_token_by_login(username, password):
         echo(
             style(
                 "\nCould not establish a connection to EvalAI."
-                " Please check the Host URL:{}.\n".format(
-                    url
+                " Please check the Host URL: {}\n".format(
+                    host_url
                 ),
                 bold=True,
                 fg="red",

--- a/evalai/utils/auth.py
+++ b/evalai/utils/auth.py
@@ -39,7 +39,9 @@ def get_user_auth_token_by_login(username, password):
         echo(
             style(
                 "\nCould not establish a connection to EvalAI."
-                " Please check the Host URL.\n",
+                " Please check the Host URL:{}.\n".format(
+                    url
+                ),
                 bold=True,
                 fg="red",
             )

--- a/evalai/utils/challenges.py
+++ b/evalai/utils/challenges.py
@@ -63,7 +63,9 @@ def display_challenges(url):
         echo(
             style(
                 "\nCould not establish a connection to EvalAI."
-                " Please check the Host URL.\n",
+                " Please check the Host URL:{}.\n".format(
+                    url
+                ),
                 bold=True,
                 fg="red",
             )
@@ -114,7 +116,9 @@ def display_ongoing_challenge_list():
         echo(
             style(
                 "\nCould not establish a connection to EvalAI."
-                " Please check the Host URL.\n",
+                " Please check the Host URL:{}.\n".format(
+                    url
+                ),
                 bold=True,
                 fg="red",
             )
@@ -167,7 +171,9 @@ def get_participant_or_host_teams(url):
         echo(
             style(
                 "\nCould not establish a connection to EvalAI."
-                " Please check the Host URL.\n",
+                " Please check the Host URL:{}.\n".format(
+                    url
+                ),
                 bold=True,
                 fg="red",
             )
@@ -198,7 +204,9 @@ def get_participant_or_host_team_challenges(url, teams):
             echo(
                 style(
                     "\nCould not establish a connection to EvalAI."
-                    " Please check the Host URL.\n",
+                    " Please check the Host URL:{}.\n".format(
+                        url
+                    ),
                     bold=True,
                     fg="red",
                 )
@@ -334,7 +342,9 @@ def display_challenge_details(challenge):
         echo(
             style(
                 "\nCould not establish a connection to EvalAI."
-                " Please check the Host URL.\n",
+                " Please check the Host URL:{}.\n".format(
+                    url
+                ),
                 bold=True,
                 fg="red",
             )
@@ -408,7 +418,9 @@ def display_challenge_phase_list(challenge_id):
         echo(
             style(
                 "\nCould not establish a connection to EvalAI."
-                " Please check the Host URL.\n",
+                " Please check the Host URL:{}.\n".format(
+                    url
+                ),
                 bold=True,
                 fg="red",
             )
@@ -513,7 +525,9 @@ def display_challenge_phase_detail(challenge_id, phase_id, is_json):
         echo(
             style(
                 "\nCould not establish a connection to EvalAI."
-                " Please check the Host URL.\n",
+                " Please check the Host URL:{}.\n".format(
+                    url
+                ),
                 bold=True,
                 fg="red",
             )
@@ -581,7 +595,9 @@ def display_challenge_phase_split_list(challenge_id):
         echo(
             style(
                 "\nCould not establish a connection to EvalAI."
-                " Please check the Host URL.\n",
+                " Please check the Host URL:{}.\n".format(
+                    url
+                ),
                 bold=True,
                 fg="red",
             )
@@ -644,7 +660,9 @@ def display_leaderboard(challenge_id, phase_split_id):
         echo(
             style(
                 "\nCould not establish a connection to EvalAI."
-                " Please check the Host URL.\n",
+                " Please check the Host URL:{}.\n".format(
+                    url
+                ),
                 bold=True,
                 fg="red",
             )

--- a/evalai/utils/challenges.py
+++ b/evalai/utils/challenges.py
@@ -51,6 +51,7 @@ def display_challenges(url):
     Function to fetch & display the challenge list based on API
     """
     header = get_request_header()
+    host_url = get_host_url()
     try:
         response = requests.get(url, headers=header)
         response.raise_for_status()
@@ -63,8 +64,8 @@ def display_challenges(url):
         echo(
             style(
                 "\nCould not establish a connection to EvalAI."
-                " Please check the Host URL:{}.\n".format(
-                    url
+                " Please check the Host URL: {}\n".format(
+                    host_url
                 ),
                 bold=True,
                 fg="red",
@@ -102,6 +103,7 @@ def display_ongoing_challenge_list():
     Displays the list of ongoing challenges from the backend
     """
     url = "{}{}".format(get_host_url(), URLS.challenge_list.value)
+    host_url = get_host_url()
 
     header = get_request_header()
     try:
@@ -116,8 +118,8 @@ def display_ongoing_challenge_list():
         echo(
             style(
                 "\nCould not establish a connection to EvalAI."
-                " Please check the Host URL:{}.\n".format(
-                    url
+                " Please check the Host URL: {}\n".format(
+                    host_url
                 ),
                 bold=True,
                 fg="red",
@@ -158,6 +160,7 @@ def get_participant_or_host_teams(url):
     Returns the participant or host teams corresponding to the user
     """
     header = get_request_header()
+    host_url = get_host_url()
 
     try:
         response = requests.get(url, headers=header)
@@ -171,8 +174,8 @@ def get_participant_or_host_teams(url):
         echo(
             style(
                 "\nCould not establish a connection to EvalAI."
-                " Please check the Host URL:{}.\n".format(
-                    url
+                " Please check the Host URL: {}\n".format(
+                    host_url
                 ),
                 bold=True,
                 fg="red",
@@ -192,6 +195,7 @@ def get_participant_or_host_team_challenges(url, teams):
     challenges = []
     for team in teams:
         header = get_request_header()
+        host_url = get_host_url()
         try:
             response = requests.get(url.format(team["id"]), headers=header)
             response.raise_for_status()
@@ -204,8 +208,8 @@ def get_participant_or_host_team_challenges(url, teams):
             echo(
                 style(
                     "\nCould not establish a connection to EvalAI."
-                    " Please check the Host URL:{}.\n".format(
-                        url
+                    " Please check the Host URL: {}\n".format(
+                        host_url
                     ),
                     bold=True,
                     fg="red",
@@ -315,6 +319,7 @@ def display_challenge_details(challenge):
     url = url.format(challenge)
 
     header = get_request_header()
+    host_url = get_host_url()
     try:
         response = requests.get(url, headers=header)
         response.raise_for_status()
@@ -342,8 +347,8 @@ def display_challenge_details(challenge):
         echo(
             style(
                 "\nCould not establish a connection to EvalAI."
-                " Please check the Host URL:{}.\n".format(
-                    url
+                " Please check the Host URL: {}\n".format(
+                    host_url
                 ),
                 bold=True,
                 fg="red",
@@ -384,6 +389,7 @@ def display_challenge_phase_list(challenge_id):
     url = "{}{}".format(get_host_url(), url)
     url = url.format(challenge_id)
     headers = get_request_header()
+    host_url = get_host_url()
     try:
         response = requests.get(url, headers=headers)
         response.raise_for_status()
@@ -418,8 +424,8 @@ def display_challenge_phase_list(challenge_id):
         echo(
             style(
                 "\nCould not establish a connection to EvalAI."
-                " Please check the Host URL:{}.\n".format(
-                    url
+                " Please check the Host URL: {}\n".format(
+                    host_url
                 ),
                 bold=True,
                 fg="red",
@@ -501,6 +507,7 @@ def display_challenge_phase_detail(challenge_id, phase_id, is_json):
     url = "{}{}".format(get_host_url(), url)
     url = url.format(challenge_id, phase_id)
     headers = get_request_header()
+    host_url = get_host_url()
 
     try:
         response = requests.get(url, headers=headers)
@@ -525,8 +532,8 @@ def display_challenge_phase_detail(challenge_id, phase_id, is_json):
         echo(
             style(
                 "\nCould not establish a connection to EvalAI."
-                " Please check the Host URL:{}.\n".format(
-                    url
+                " Please check the Host URL: {}\n".format(
+                    host_url
                 ),
                 bold=True,
                 fg="red",
@@ -572,6 +579,7 @@ def display_challenge_phase_split_list(challenge_id):
     url = "{}{}".format(get_host_url(), url)
     url = url.format(challenge_id)
     headers = get_request_header()
+    host_url = get_host_url()
     try:
         response = requests.get(url, headers=headers)
         response.raise_for_status()
@@ -595,8 +603,8 @@ def display_challenge_phase_split_list(challenge_id):
         echo(
             style(
                 "\nCould not establish a connection to EvalAI."
-                " Please check the Host URL:{}.\n".format(
-                    url
+                " Please check the Host URL: {}\n".format(
+                    host_url
                 ),
                 bold=True,
                 fg="red",
@@ -640,6 +648,7 @@ def display_leaderboard(challenge_id, phase_split_id):
     url = "{}{}".format(get_host_url(), URLS.leaderboard.value)
     url = url.format(phase_split_id)
     headers = get_request_header()
+    host_url = get_host_url()
     try:
         response = requests.get(url, headers=headers)
         response.raise_for_status()
@@ -660,8 +669,8 @@ def display_leaderboard(challenge_id, phase_split_id):
         echo(
             style(
                 "\nCould not establish a connection to EvalAI."
-                " Please check the Host URL:{}.\n".format(
-                    url
+                " Please check the Host URL: {}\n".format(
+                    host_url
                 ),
                 bold=True,
                 fg="red",

--- a/evalai/utils/requests.py
+++ b/evalai/utils/requests.py
@@ -13,6 +13,7 @@ from .auth import get_request_header, get_host_url
 def make_request(path, method, files=None, data=None):
     url = "{}{}".format(get_host_url(), path)
     headers = get_request_header()
+    host_url = get_host_url()
 
     if method == "GET":
         try:
@@ -35,8 +36,8 @@ def make_request(path, method, files=None, data=None):
             echo(
                 style(
                     "\nCould not establish a connection to EvalAI."
-                    " Please check the Host URL:{}.\n".format(
-                        url
+                    " Please check the Host URL: {}\n".format(
+                        host_url
                     ),
                     bold=True,
                     fg="red",
@@ -75,8 +76,8 @@ def make_request(path, method, files=None, data=None):
             echo(
                 style(
                     "\nCould not establish a connection to EvalAI."
-                    " Please check the Host URL:{}.\n".format(
-                        url
+                    " Please check the Host URL: {}\n".format(
+                        host_url
                     ),
                     bold=True,
                     fg="red",

--- a/evalai/utils/requests.py
+++ b/evalai/utils/requests.py
@@ -35,7 +35,9 @@ def make_request(path, method, files=None, data=None):
             echo(
                 style(
                     "\nCould not establish a connection to EvalAI."
-                    " Please check the Host URL.\n",
+                    " Please check the Host URL:{}.\n".format(
+                        url
+                    ),
                     bold=True,
                     fg="red",
                 )
@@ -73,7 +75,9 @@ def make_request(path, method, files=None, data=None):
             echo(
                 style(
                     "\nCould not establish a connection to EvalAI."
-                    " Please check the Host URL.\n",
+                    " Please check the Host URL:{}.\n".format(
+                        url
+                    ),
                     bold=True,
                     fg="red",
                 )

--- a/evalai/utils/submissions.py
+++ b/evalai/utils/submissions.py
@@ -24,6 +24,7 @@ def make_submission(challenge_id, phase_id, file, submission_metadata={}):
     """
     url = "{}{}".format(get_host_url(), URLS.make_submission.value)
     url = url.format(challenge_id, phase_id)
+    host_url = get_host_url()
 
     headers = get_request_header()
     input_file = {"input_file": file}
@@ -57,8 +58,8 @@ def make_submission(challenge_id, phase_id, file, submission_metadata={}):
         echo(
             style(
                 "\nCould not establish a connection to EvalAI."
-                " Please check the Host URL:{}.\n".format(
-                    url
+                " Please check the Host URL: {}\n".format(
+                    host_url
                 ),
                 bold=True,
                 fg="red",
@@ -150,6 +151,7 @@ def display_my_submission_details(
     url = "{}{}".format(get_host_url(), url)
     url = url.format(challenge_id, phase_id)
     headers = get_request_header()
+    host_url = get_host_url()
 
     try:
         response = requests.get(url, headers=headers)
@@ -174,8 +176,8 @@ def display_my_submission_details(
         echo(
             style(
                 "\nCould not establish a connection to EvalAI."
-                " Please check the Host URL:{}.\n".format(
-                    url
+                " Please check the Host URL: {}\n".format(
+                    host_url
                 ),
                 bold=True,
                 fg="red",
@@ -224,6 +226,7 @@ def submission_details_request(submission_id):
     url = "{}{}".format(get_host_url(), URLS.get_submission.value)
     url = url.format(submission_id)
     headers = get_request_header()
+    host_url = get_host_url()
     try:
         response = requests.get(url, headers=headers)
         response.raise_for_status()
@@ -248,8 +251,8 @@ def submission_details_request(submission_id):
         echo(
             style(
                 "\nCould not establish a connection to EvalAI."
-                " Please check the Host URL:{}.\n".format(
-                    url
+                " Please check the Host URL: {}\n".format(
+                    host_url
                 ),
                 bold=True,
                 fg="red",

--- a/evalai/utils/submissions.py
+++ b/evalai/utils/submissions.py
@@ -57,7 +57,9 @@ def make_submission(challenge_id, phase_id, file, submission_metadata={}):
         echo(
             style(
                 "\nCould not establish a connection to EvalAI."
-                " Please check the Host URL.\n",
+                " Please check the Host URL:{}.\n".format(
+                    url
+                ),
                 bold=True,
                 fg="red",
             )
@@ -172,7 +174,9 @@ def display_my_submission_details(
         echo(
             style(
                 "\nCould not establish a connection to EvalAI."
-                " Please check the Host URL.\n",
+                " Please check the Host URL:{}.\n".format(
+                    url
+                ),
                 bold=True,
                 fg="red",
             )
@@ -244,7 +248,9 @@ def submission_details_request(submission_id):
         echo(
             style(
                 "\nCould not establish a connection to EvalAI."
-                " Please check the Host URL.\n",
+                " Please check the Host URL:{}.\n".format(
+                    url
+                ),
                 bold=True,
                 fg="red",
             )

--- a/evalai/utils/teams.py
+++ b/evalai/utils/teams.py
@@ -53,6 +53,7 @@ def display_teams(is_host):
     """
     url = "{}{}"
     headers = get_request_header()
+    host_url = get_host_url()
     if is_host:
         url = url.format(get_host_url(), URLS.host_team_list.value)
     else:
@@ -78,8 +79,8 @@ def display_teams(is_host):
         echo(
             style(
                 "\nCould not establish a connection to EvalAI."
-                " Please check the Host URL:{}.\n".format(
-                    url
+                " Please check the Host URL: {}\n".format(
+                    host_url
                 ),
                 bold=True,
                 fg="red",
@@ -100,6 +101,7 @@ def create_team(team_name, team_url, is_host):
     Function to create a new team by taking in the team name as input.
     """
     url = "{}{}"
+    host_url = get_host_url()
 
     if is_host:
         url = url.format(get_host_url(), URLS.create_host_team.value)
@@ -144,8 +146,8 @@ def create_team(team_name, team_url, is_host):
         echo(
             style(
                 "\nCould not establish a connection to EvalAI."
-                " Please check the Host URL:{}.\n".format(
-                    url
+                " Please check the Host URL: {}\n".format(
+                    host_url
                 ),
                 bold=True,
                 fg="red",
@@ -184,6 +186,7 @@ def participate_in_a_challenge(challenge_id, participant_team_id):
 
     url = "{}{}".format(get_host_url(), URLS.participate_in_a_challenge.value)
     url = url.format(challenge_id, participant_team_id)
+    host_url = get_host_url()
 
     headers = get_request_header()
     headers["Content-Type"] = "application/json"
@@ -210,8 +213,8 @@ def participate_in_a_challenge(challenge_id, participant_team_id):
         echo(
             style(
                 "\nCould not establish a connection to EvalAI."
-                " Please check the Host URL:{}.\n".format(
-                    url
+                " Please check the Host URL: {}\n".format(
+                    host_url
                 ),
                 bold=True,
                 fg="red",

--- a/evalai/utils/teams.py
+++ b/evalai/utils/teams.py
@@ -78,7 +78,9 @@ def display_teams(is_host):
         echo(
             style(
                 "\nCould not establish a connection to EvalAI."
-                " Please check the Host URL.\n",
+                " Please check the Host URL:{}.\n".format(
+                    url
+                ),
                 bold=True,
                 fg="red",
             )
@@ -142,7 +144,9 @@ def create_team(team_name, team_url, is_host):
         echo(
             style(
                 "\nCould not establish a connection to EvalAI."
-                " Please check the Host URL.\n",
+                " Please check the Host URL:{}.\n".format(
+                    url
+                ),
                 bold=True,
                 fg="red",
             )
@@ -206,7 +210,9 @@ def participate_in_a_challenge(challenge_id, participant_team_id):
         echo(
             style(
                 "\nCould not establish a connection to EvalAI."
-                " Please check the Host URL.\n",
+                " Please check the Host URL:{}.\n".format(
+                    url
+                ),
                 bold=True,
                 fg="red",
             )


### PR DESCRIPTION

Fix for enhancement#1001: Google Code-in Task to update the error message

As per Mentor's feedback, I fixed the error message so that it only show the host details of the host url.

======

This is for Google Code-in Task. Updated the error message to add the URL of the API end point to the end of the existing error message.  Currently it shows as " Please check the Host URL" and it is modified to add the host url at the end of this message. ex: if the CLI is not able to connect to https://api.evalai.example the error should be "Could not establish connection to EvalAI. Please check the Host URL: https://api.evalai.example".