### PR TITLE
[small, pypi] Fix #200, corrected link to homepage on pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     long_description_content_type="text/markdown",
     author="Cloud-CV",
     author_email="team@cloudcv.org",
-    url="https://github.com/Cloud-CV/evalai_cli ",
+    url="https://github.com/Cloud-CV/evalai-cli",
     classifiers=(
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
As per https://github.com/Cloud-CV/evalai-cli/issues/200, link to Homepage under Project Links was broken. Made the fix here.
`https://github.com/Cloud-CV/evalai_cli` --> `https://github.com/Cloud-CV/evalai-cli`