### PR TITLE
Add command to setup the CLI

### DIFF
--- a/evalai/login.py
+++ b/evalai/login.py
@@ -8,13 +8,13 @@ from evalai.utils.config import AUTH_TOKEN_PATH, AUTH_TOKEN_DIR
 
 
 @click.group(invoke_without_command=True)
+@click.option('-p', '--password', type=str, hide_input=True, prompt=True)
+@click.option('-u', '--username', type=str, hide_input=False, prompt=True)
 @click.pass_context
-def login(ctx):
+def login(ctx, username, password):
     """
     Login to EvalAI and save token.
     """
-    username = click.prompt("username", type=str, hide_input=False)
-    password = click.prompt("Enter password", type=str, hide_input=True)
     token = get_user_auth_token_by_login(username, password)
 
     if os.path.exists(AUTH_TOKEN_PATH):

--- a/evalai/main.py
+++ b/evalai/main.py
@@ -9,6 +9,7 @@ from .submissions import submission, push, download_file
 from .teams import teams
 from .get_token import get_token
 from .login import login
+from .setup import ignite
 
 
 @click.version_option()
@@ -43,3 +44,4 @@ main.add_command(submission)
 main.add_command(teams)
 main.add_command(get_token)
 main.add_command(login)
+main.add_command(ignite)

--- a/evalai/setup.py
+++ b/evalai/setup.py
@@ -14,7 +14,7 @@ from evalai.utils.auth import (
 )
 
 previous_host_url = get_host_url()
-username_help_message = "Required: our EvalAI username"
+username_help_message = "Required: Your EvalAI username"
 password_help_message = "Required: Your EvalAI password"
 host_help_message = "Optional: URL of the API host,\
                     currently set to: {}".format(previous_host_url)
@@ -41,10 +41,14 @@ def ignite(ctx, username, password, host):
         ctx.invoke(login, username=username, password=password)
         current_auth_token = get_user_auth_token()
         user_auth_token = get_user_auth_token_by_login(username, password)
-        if current_auth_token != user_auth_token and host != previous_host_url:
-            message = "Login failed. Reverting host URL from {0} to {1}"
-            echo(style(message.format(host, previous_host_url), bold=True))
-            ctx.invoke(set_host, set_host=previous_host_url)
+        if current_auth_token != user_auth_token:
+            echo(style("Login failed.", bold=True))
+            if host != previous_host_url:
+                message = "Reverting host URL from {0} to {1}"
+                echo(style(message.format(host, previous_host_url), bold=True))
+                ctx.invoke(set_host, set_host=previous_host_url)
+        else:
+            echo(style("Setup successful."))
     else:
         # A more detailed error message is shown by set_host command already.
         echo(style("Couldn't set host URL to {}".format(host), bold=True))

--- a/evalai/setup.py
+++ b/evalai/setup.py
@@ -1,0 +1,53 @@
+import click
+import os
+
+from click import echo, style
+
+from .add_token import set_token
+from .login import login
+from .main import main
+from .set_host import host as set_host  # 'host' would be a confusing name
+from evalai.utils.auth import (
+    get_host_url,
+    get_user_auth_token,
+    get_user_auth_token_by_login
+)
+
+previous_host_url = get_host_url()
+username_help_message = "Required: our EvalAI username"
+password_help_message = "Required: Your EvalAI password"
+host_help_message = "Optional: URL of the API host,\
+                    currently set to: {}".format(previous_host_url)
+
+@click.command
+@click.option('-h', '--host',
+                default=previous_host_url,
+                help=host_help_message)
+@click.option('-p', '--password', prompt=True, help=password_help_message)
+@click.option('-u', '--username', prompt=True, help=username_help_message)
+@click.pass_context
+def ignite(ctx, username, password, host):
+    """
+    Set up basic configuration: host and auth key
+    """
+    """
+    Invoked by `evalai ignite -u USER -p PASSWORD [-h HOST]`
+    """
+    echo(style("Booting up EvalAI", bold=True))
+    ctx.invoke(main)
+    if host != previous_host_url:
+        ctx.invoke(set_host, set_host=host)
+    if get_host_url() == host:  # check if the set_host command worked.
+        ctx.invoke(login, username=username, password=password)
+        current_auth_token = get_user_auth_token()
+        user_auth_token = get_user_auth_token_by_login(username, password)
+        if current_auth_token != user_auth_token and host != previous_host_url:
+            message = "Login failed. Reverting host URL from {0} to {1}"
+            echo(style(message.format(host, previous_host_url), bold=True))
+            ctx.invoke(set_host, set_host=previous_host_url)
+    else:
+        # A more detailed error message is shown by set_host command already.
+        echo(style("Couldn't set host URL to {}".format(host), bold=True))
+        # Using get_host_url() rather than previous_host_url so that any
+        # future bugs are discovered easily.
+        echo(style("Current host URL: {}".format(get_host_url()), bold=True))

--- a/evalai/setup.py
+++ b/evalai/setup.py
@@ -20,8 +20,8 @@ host_help_message = "Optional: URL of the API host,\
 
 @click.command
 @click.option('-h', '--host',
-    default=previous_host_url,
-    help=host_help_message)
+            default=previous_host_url,
+            help=host_help_message)
 @click.option('-p', '--password', prompt=True, help=password_help_message)
 @click.option('-u', '--username', prompt=True, help=username_help_message)
 @click.pass_context

--- a/evalai/setup.py
+++ b/evalai/setup.py
@@ -1,9 +1,7 @@
 import click
-import os
 
 from click import echo, style
 
-from .add_token import set_token
 from .login import login
 from .main import main
 from .set_host import host as set_host  # 'host' would be a confusing name
@@ -19,10 +17,11 @@ password_help_message = "Required: Your EvalAI password"
 host_help_message = "Optional: URL of the API host,\
                     currently set to: {}".format(previous_host_url)
 
+
 @click.command
 @click.option('-h', '--host',
-                default=previous_host_url,
-                help=host_help_message)
+    default=previous_host_url,
+    help=host_help_message)
 @click.option('-p', '--password', prompt=True, help=password_help_message)
 @click.option('-u', '--username', prompt=True, help=username_help_message)
 @click.pass_context

--- a/evalai/setup.py
+++ b/evalai/setup.py
@@ -20,8 +20,8 @@ host_help_message = "Optional: URL of the API host,\
 
 @click.command
 @click.option('-h', '--host',
-            default=previous_host_url,
-            help=host_help_message)
+              default=previous_host_url,
+              help=host_help_message)
 @click.option('-p', '--password', prompt=True, help=password_help_message)
 @click.option('-u', '--username', prompt=True, help=username_help_message)
 @click.pass_context


### PR DESCRIPTION
Changes proposed in this PR:
    * Update `login.py` to allow calling from another command
    * Added command to set up the CLI configuration like host and auth token
    * Command example:
```
evalai ignite -u USER -p PASSWORD [-h HOST]
```
    * Added unit tests for the above command still in progress, but thought I could gain some feedback on the main code in the meanwhile:

P.S.: I tried using a fancy name and showing EvalAI in Text Art form to make it a little interesting 😅 . Please let me know if that needs to be changed.

Mentors: @vkartik97 @pushkalkatara @Ram81 @RishabhJain2018 @yashdusing