### PR TITLE
UPDATED: Make Output Color Across The CLI Messages Consistent According To Convention

### DIFF
--- a/evalai/add_token.py
+++ b/evalai/add_token.py
@@ -42,5 +42,6 @@ def set_token(auth_token):
                     LEN_OF_TOKEN
                 ),
                 bold=True,
+                fg="red"
             )
         )

--- a/evalai/teams.py
+++ b/evalai/teams.py
@@ -66,7 +66,7 @@ def create(team):
             while not (
                 validators.url(team_url) or validators.domain(team_url)
             ):
-                echo(style("Sorry, please enter a valid link.", bold=True, fg="red")_
+                echo(style("Sorry, please enter a valid link.", bold=True, fg="red"))
                 team_url = click.prompt("Team URL", type=str)
 
         is_host = team == "host"

--- a/evalai/teams.py
+++ b/evalai/teams.py
@@ -66,7 +66,7 @@ def create(team):
             while not (
                 validators.url(team_url) or validators.domain(team_url)
             ):
-                echo("Sorry, please enter a valid link.")
+                echo(style("Sorry, please enter a valid link.", bold=True, fg="red")_
                 team_url = click.prompt("Team URL", type=str)
 
         is_host = team == "host"

--- a/evalai/utils/auth.py
+++ b/evalai/utils/auth.py
@@ -59,7 +59,7 @@ def get_user_auth_token():
             try:
                 data = TokenObj.read()
             except (OSError, IOError) as e:
-                echo(e)
+                echo(style(e, bold=True, fg="red"))
         data = json.loads(data)
         token = data["token"]
         return token
@@ -97,4 +97,4 @@ def get_host_url():
                 data = fr.read()
                 return str(data)
             except (OSError, IOError) as e:
-                echo(e)
+                echo(style(e, bold=True, fg="red"))

--- a/evalai/utils/challenges.py
+++ b/evalai/utils/challenges.py
@@ -84,7 +84,7 @@ def display_challenges(url):
     if len(challenges) != 0:
         pretty_print_challenge_data(challenges)
     else:
-        echo("Sorry, no challenges found.")
+        echo(style("Sorry, no challenges found.", bold=True, fg="red"))
 
 
 def display_all_challenge_list():
@@ -146,7 +146,7 @@ def display_ongoing_challenge_list():
     if len(challenges) != 0:
         pretty_print_challenge_data(challenges)
     else:
-        echo("Sorry, no challenges found.")
+        echo(style("Sorry, no challenges found.", bold=True, fg="red"))
 
 
 def display_future_challenge_list():
@@ -241,7 +241,7 @@ def display_participated_or_hosted_challenges(
         if len(challenges) != 0:
             pretty_print_challenge_data(challenges)
         else:
-            echo("Sorry, no challenges found.")
+            echo(style("Sorry, no challenges found.", bold=True, fg="red"))
 
     if is_participant:
         team_url = "{}{}".format(get_host_url(), URLS.participant_teams.value)
@@ -272,9 +272,9 @@ def display_participated_or_hosted_challenges(
                 echo(style("\nParticipated Challenges\n", bold=True))
                 pretty_print_challenge_data(challenges)
             else:
-                echo("Sorry, no challenges found.")
+                echo(style("Sorry, no challenges found.", bold=True, fg="red"))
         else:
-            echo("Sorry, no challenges found.")
+            echo(style("Sorry, no challenges found.", bold=True, fg="red"))
 
 
 def pretty_print_challenge_details(challenge):
@@ -600,7 +600,7 @@ def display_challenge_phase_split_list(challenge_id):
     if len(phase_splits) != 0:
         pretty_print_challenge_phase_split_data(phase_splits)
     else:
-        echo("Sorry, no Challenge Phase Splits found.")
+        echo(style("Sorry, no Challenge Phase Splits found.", bold=True, fg="red"))
 
 
 def pretty_print_leaderboard_data(attributes, results):
@@ -666,4 +666,4 @@ def display_leaderboard(challenge_id, phase_split_id):
         attributes = results[0]["leaderboard__schema"]["labels"]
         pretty_print_leaderboard_data(attributes, results)
     else:
-        echo("Sorry, no Leaderboard results found.")
+        echo(style("Sorry, no Leaderboard results found.", bold=True, fg="red"))

--- a/evalai/utils/challenges.py
+++ b/evalai/utils/challenges.py
@@ -65,7 +65,7 @@ def display_challenges(url):
     except requests.exceptions.HTTPError as err:
         if response.status_code == 401:
             validate_token(response.json())
-        echo(err)
+        echo(style(err, bold=True, fg="red"))
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(
@@ -84,7 +84,7 @@ def display_challenges(url):
     if len(challenges) != 0:
         pretty_print_challenge_data(challenges)
     else:
-        echo("Sorry, no challenges found.")
+        echo(style("Sorry, no challenges found."), bold=True, fg="red")
 
 
 def display_all_challenge_list():
@@ -116,7 +116,7 @@ def display_ongoing_challenge_list():
     except requests.exceptions.HTTPError as err:
         if response.status_code == 401:
             validate_token(response.json())
-        echo(err)
+        echo(style(err, bold=True, fg="red"))
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(
@@ -146,7 +146,7 @@ def display_ongoing_challenge_list():
     if len(challenges) != 0:
         pretty_print_challenge_data(challenges)
     else:
-        echo("Sorry, no challenges found.")
+        echo(style("Sorry, no challenges found.", bold=True, fg="red"))
 
 
 def display_future_challenge_list():
@@ -169,7 +169,7 @@ def get_participant_or_host_teams(url):
     except requests.exceptions.HTTPError as err:
         if response.status_code == 401:
             validate_token(response.json())
-        echo(err)
+        echo(style(err, bold=True, fg="red"))
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(
@@ -200,7 +200,7 @@ def get_participant_or_host_team_challenges(url, teams):
         except requests.exceptions.HTTPError as err:
             if response.status_code == 401:
                 validate_token(response.json())
-            echo(err)
+            echo(style(err, bold=True, fg="red"))
             sys.exit(1)
         except requests.exceptions.RequestException:
             echo(
@@ -241,7 +241,7 @@ def display_participated_or_hosted_challenges(
         if len(challenges) != 0:
             pretty_print_challenge_data(challenges)
         else:
-            echo("Sorry, no challenges found.")
+            echo(style("Sorry, no challenges found.", bold=True, fg="red"))
 
     if is_participant:
         team_url = "{}{}".format(get_host_url(), URLS.participant_teams.value)
@@ -272,9 +272,9 @@ def display_participated_or_hosted_challenges(
                 echo(style("\nParticipated Challenges\n", bold=True))
                 pretty_print_challenge_data(challenges)
             else:
-                echo("Sorry, no challenges found.")
+                echo(style("Sorry, no challenges found.", bold=True, fg="red"))
         else:
-            echo("Sorry, no challenges found.")
+            echo(style("Sorry, no challenges found.", bold=True, fg="red"))
 
 
 def pretty_print_challenge_details(challenge):
@@ -336,7 +336,7 @@ def display_challenge_details(challenge):
                 )
             )
         else:
-            echo(err)
+            echo(style(err, bold=True, fg="red"))
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(
@@ -410,7 +410,7 @@ def display_challenge_phase_list(challenge_id):
                 )
             )
         else:
-            echo(err)
+            echo(style(err, bold=True, fg="red"))
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(
@@ -515,7 +515,7 @@ def display_challenge_phase_detail(challenge_id, phase_id, is_json):
                 )
             )
         else:
-            echo(err)
+            echo(style(err, bold=True, fg="red"))
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(
@@ -583,7 +583,7 @@ def display_challenge_phase_split_list(challenge_id):
                 )
             )
         else:
-            echo(err)
+            echo(style(err, bold=True, fg="red"))
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(
@@ -600,7 +600,7 @@ def display_challenge_phase_split_list(challenge_id):
     if len(phase_splits) != 0:
         pretty_print_challenge_phase_split_data(phase_splits)
     else:
-        echo("Sorry, no Challenge Phase Splits found.")
+        echo(style("Sorry, no Challenge Phase Splits found.", bold=True, fg="red"))
 
 
 def pretty_print_leaderboard_data(attributes, results):
@@ -646,7 +646,7 @@ def display_leaderboard(challenge_id, phase_split_id):
                 )
             )
         else:
-            echo(err)
+            echo(style(err, bold=True, fg="red"))
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(
@@ -666,4 +666,4 @@ def display_leaderboard(challenge_id, phase_split_id):
         attributes = results[0]["leaderboard__schema"]["labels"]
         pretty_print_leaderboard_data(attributes, results)
     else:
-        echo("Sorry, no Leaderboard results found.")
+        echo(style("Sorry, no Leaderboard results found.", bold=True, fg="red"))

--- a/evalai/utils/challenges.py
+++ b/evalai/utils/challenges.py
@@ -84,7 +84,7 @@ def display_challenges(url):
     if len(challenges) != 0:
         pretty_print_challenge_data(challenges)
     else:
-        echo(style("\nSorry, no challenges found.\n"), bold=True, fg="red")
+        echo(style("Sorry, no challenges found.", bold=True, fg="red"))
 
 
 def display_all_challenge_list():
@@ -146,7 +146,7 @@ def display_ongoing_challenge_list():
     if len(challenges) != 0:
         pretty_print_challenge_data(challenges)
     else:
-        echo(style("\nSorry, no challenges found.\n", bold=True, fg="red"))
+        echo(style("Sorry, no challenges found.", bold=True, fg="red"))
 
 
 def display_future_challenge_list():
@@ -241,7 +241,7 @@ def display_participated_or_hosted_challenges(
         if len(challenges) != 0:
             pretty_print_challenge_data(challenges)
         else:
-            echo(style("\nSorry, no challenges found.\n", bold=True, fg="red"))
+            echo(style("Sorry, no challenges found.", bold=True, fg="red"))
 
     if is_participant:
         team_url = "{}{}".format(get_host_url(), URLS.participant_teams.value)
@@ -272,9 +272,9 @@ def display_participated_or_hosted_challenges(
                 echo(style("\nParticipated Challenges\n", bold=True))
                 pretty_print_challenge_data(challenges)
             else:
-                echo(style("\nSorry, no challenges found.\n", bold=True, fg="red"))
+                echo(style("Sorry, no challenges found.", bold=True, fg="red"))
         else:
-            echo(style("\nSorry, no challenges found.\n", bold=True, fg="red"))
+            echo(style("Sorry, no challenges found.", bold=True, fg="red"))
 
 
 def pretty_print_challenge_details(challenge):

--- a/evalai/utils/challenges.py
+++ b/evalai/utils/challenges.py
@@ -65,7 +65,7 @@ def display_challenges(url):
     except requests.exceptions.HTTPError as err:
         if response.status_code == 401:
             validate_token(response.json())
-        echo(style(err, bold=True, fg="red"))
+        echo(err)
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(
@@ -84,7 +84,7 @@ def display_challenges(url):
     if len(challenges) != 0:
         pretty_print_challenge_data(challenges)
     else:
-        echo(style("Sorry, no challenges found.", bold=True, fg="red"))
+        echo("Sorry, no challenges found.")
 
 
 def display_all_challenge_list():
@@ -146,7 +146,7 @@ def display_ongoing_challenge_list():
     if len(challenges) != 0:
         pretty_print_challenge_data(challenges)
     else:
-        echo(style("Sorry, no challenges found.", bold=True, fg="red"))
+        echo("Sorry, no challenges found.")
 
 
 def display_future_challenge_list():
@@ -241,7 +241,7 @@ def display_participated_or_hosted_challenges(
         if len(challenges) != 0:
             pretty_print_challenge_data(challenges)
         else:
-            echo(style("Sorry, no challenges found.", bold=True, fg="red"))
+            echo("Sorry, no challenges found.")
 
     if is_participant:
         team_url = "{}{}".format(get_host_url(), URLS.participant_teams.value)
@@ -272,9 +272,9 @@ def display_participated_or_hosted_challenges(
                 echo(style("\nParticipated Challenges\n", bold=True))
                 pretty_print_challenge_data(challenges)
             else:
-                echo(style("Sorry, no challenges found.", bold=True, fg="red"))
+                echo("Sorry, no challenges found.")
         else:
-            echo(style("Sorry, no challenges found.", bold=True, fg="red"))
+            echo("Sorry, no challenges found.")
 
 
 def pretty_print_challenge_details(challenge):
@@ -600,7 +600,7 @@ def display_challenge_phase_split_list(challenge_id):
     if len(phase_splits) != 0:
         pretty_print_challenge_phase_split_data(phase_splits)
     else:
-        echo(style("Sorry, no Challenge Phase Splits found.", bold=True, fg="red"))
+        echo("Sorry, no Challenge Phase Splits found.")
 
 
 def pretty_print_leaderboard_data(attributes, results):
@@ -666,4 +666,5 @@ def display_leaderboard(challenge_id, phase_split_id):
         attributes = results[0]["leaderboard__schema"]["labels"]
         pretty_print_leaderboard_data(attributes, results)
     else:
-        echo(style("Sorry, no Leaderboard results found.", bold=True, fg="red"))
+        echo("Sorry, no Leaderboard results found.")
+        

--- a/evalai/utils/challenges.py
+++ b/evalai/utils/challenges.py
@@ -116,7 +116,7 @@ def display_ongoing_challenge_list():
     except requests.exceptions.HTTPError as err:
         if response.status_code == 401:
             validate_token(response.json())
-        echo(style(err, bold=True, fg="red"))
+        echo(err)
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(
@@ -169,7 +169,7 @@ def get_participant_or_host_teams(url):
     except requests.exceptions.HTTPError as err:
         if response.status_code == 401:
             validate_token(response.json())
-        echo(style(err, bold=True, fg="red"))
+        echo(err)
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(
@@ -200,7 +200,7 @@ def get_participant_or_host_team_challenges(url, teams):
         except requests.exceptions.HTTPError as err:
             if response.status_code == 401:
                 validate_token(response.json())
-            echo(style(err, bold=True, fg="red"))
+            echo(err)
             sys.exit(1)
         except requests.exceptions.RequestException:
             echo(
@@ -336,7 +336,7 @@ def display_challenge_details(challenge):
                 )
             )
         else:
-            echo(style(err, bold=True, fg="red"))
+            echo(err)
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(
@@ -410,7 +410,7 @@ def display_challenge_phase_list(challenge_id):
                 )
             )
         else:
-            echo(style(err, bold=True, fg="red"))
+            echo(err)
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(
@@ -515,7 +515,7 @@ def display_challenge_phase_detail(challenge_id, phase_id, is_json):
                 )
             )
         else:
-            echo(style(err, bold=True, fg="red"))
+            echo(err)
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(
@@ -583,7 +583,7 @@ def display_challenge_phase_split_list(challenge_id):
                 )
             )
         else:
-            echo(style(err, bold=True, fg="red"))
+            echo(err)
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(
@@ -646,7 +646,7 @@ def display_leaderboard(challenge_id, phase_split_id):
                 )
             )
         else:
-            echo(style(err, bold=True, fg="red"))
+            echo(err)
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(

--- a/evalai/utils/challenges.py
+++ b/evalai/utils/challenges.py
@@ -84,7 +84,7 @@ def display_challenges(url):
     if len(challenges) != 0:
         pretty_print_challenge_data(challenges)
     else:
-        echo(style("Sorry, no challenges found."), bold=True, fg="red")
+        echo(style("\nSorry, no challenges found.\n"), bold=True, fg="red")
 
 
 def display_all_challenge_list():
@@ -146,7 +146,7 @@ def display_ongoing_challenge_list():
     if len(challenges) != 0:
         pretty_print_challenge_data(challenges)
     else:
-        echo(style("Sorry, no challenges found.", bold=True, fg="red"))
+        echo(style("\nSorry, no challenges found.\n", bold=True, fg="red"))
 
 
 def display_future_challenge_list():
@@ -241,7 +241,7 @@ def display_participated_or_hosted_challenges(
         if len(challenges) != 0:
             pretty_print_challenge_data(challenges)
         else:
-            echo(style("Sorry, no challenges found.", bold=True, fg="red"))
+            echo(style("\nSorry, no challenges found.\n", bold=True, fg="red"))
 
     if is_participant:
         team_url = "{}{}".format(get_host_url(), URLS.participant_teams.value)
@@ -272,9 +272,9 @@ def display_participated_or_hosted_challenges(
                 echo(style("\nParticipated Challenges\n", bold=True))
                 pretty_print_challenge_data(challenges)
             else:
-                echo(style("Sorry, no challenges found.", bold=True, fg="red"))
+                echo(style("\nSorry, no challenges found.\n", bold=True, fg="red"))
         else:
-            echo(style("Sorry, no challenges found.", bold=True, fg="red"))
+            echo(style("\nSorry, no challenges found.\n", bold=True, fg="red"))
 
 
 def pretty_print_challenge_details(challenge):

--- a/evalai/utils/challenges.py
+++ b/evalai/utils/challenges.py
@@ -667,4 +667,3 @@ def display_leaderboard(challenge_id, phase_split_id):
         pretty_print_leaderboard_data(attributes, results)
     else:
         echo("Sorry, no Leaderboard results found.")
-        

--- a/evalai/utils/requests.py
+++ b/evalai/utils/requests.py
@@ -93,6 +93,7 @@ def make_request(path, method, files=None, data=None):
                     response.get("id")
                 ),
                 bold=True,
+                fg="white"
             )
         )
         return response

--- a/evalai/utils/requests.py
+++ b/evalai/utils/requests.py
@@ -105,4 +105,3 @@ def make_request(path, method, files=None, data=None):
     elif method == "DELETE":
         # TODO: Add support for DELETE request
         pass
-        

--- a/evalai/utils/requests.py
+++ b/evalai/utils/requests.py
@@ -29,7 +29,7 @@ def make_request(path, method, files=None, data=None):
                     )
                 )
             else:
-                echo(style(err, bold=True, fg="red"))
+                echo(err)
             sys.exit(1)
         except requests.exceptions.RequestException:
             echo(
@@ -67,7 +67,7 @@ def make_request(path, method, files=None, data=None):
                     )
                 )
             else:
-                echo(style(err, bold=True, fg="red"))
+                echo(err)
             sys.exit(1)
         except requests.exceptions.RequestException:
             echo(

--- a/evalai/utils/requests.py
+++ b/evalai/utils/requests.py
@@ -93,7 +93,6 @@ def make_request(path, method, files=None, data=None):
                     response.get("id")
                 ),
                 bold=True,
-                fg="white"
             )
         )
         return response
@@ -106,3 +105,4 @@ def make_request(path, method, files=None, data=None):
     elif method == "DELETE":
         # TODO: Add support for DELETE request
         pass
+        

--- a/evalai/utils/requests.py
+++ b/evalai/utils/requests.py
@@ -29,7 +29,7 @@ def make_request(path, method, files=None, data=None):
                     )
                 )
             else:
-                echo(err)
+                echo(style(err, bold=True, fg="red"))
             sys.exit(1)
         except requests.exceptions.RequestException:
             echo(
@@ -67,7 +67,7 @@ def make_request(path, method, files=None, data=None):
                     )
                 )
             else:
-                echo(err)
+                echo(style(err, bold=True, fg="red"))
             sys.exit(1)
         except requests.exceptions.RequestException:
             echo(
@@ -93,6 +93,7 @@ def make_request(path, method, files=None, data=None):
                     response.get("id")
                 ),
                 bold=True,
+                fg="white"
             )
         )
         return response

--- a/evalai/utils/submissions.py
+++ b/evalai/utils/submissions.py
@@ -49,7 +49,7 @@ def make_submission(challenge_id, phase_id, file, submission_metadata={}):
                 )
             )
         else:
-            echo(style(err, bold=True, fg="red"))
+            echo(err)
         if "input_file" in response.json():
             echo(style(response.json()["input_file"][0], fg="red", bold=True))
         sys.exit(1)
@@ -79,7 +79,6 @@ def make_submission(challenge_id, phase_id, file, submission_metadata={}):
                 response["id"]
             ),
             bold=True,
-            fg="white",
         )
     )
 
@@ -104,7 +103,6 @@ def pretty_print_my_submissions_data(submissions, start_date, end_date):
             style(
                 "\nSorry, you have not made any submissions to this challenge phase.\n",
                 bold=True,
-                fg="red"
             )
         )
         sys.exit(1)
@@ -134,7 +132,6 @@ def pretty_print_my_submissions_data(submissions, start_date, end_date):
             style(
                 "\nSorry, no submissions were made during this time period.\n",
                 bold=True,
-                fg="red",
             )
         )
         sys.exit(1)
@@ -169,7 +166,7 @@ def display_my_submission_details(
                 )
             )
         else:
-            echo(style(err, bold=True, fg="red"))
+            echo(err)
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(
@@ -241,7 +238,7 @@ def submission_details_request(submission_id):
                 )
             )
         else:
-            echo(style(err, bold=True, fg="red"))
+            echo(err)
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(
@@ -276,7 +273,7 @@ def display_submission_result(submission_id):
             style(
                 "\nThe Submission is yet to be evaluated.\n",
                 bold=True,
-                fg="red",
+                fg="yellow",
             )
         )
 
@@ -284,7 +281,6 @@ def display_submission_result(submission_id):
 def convert_bytes_to(byte, to, bsize=1024):
     """
     Convert bytes to KB, MB, GB etc.
-
     Arguments:
         bytes {int} -- The bytes which is to be converted
         to {str} -- To which unit it is to be converted
@@ -295,3 +291,4 @@ def convert_bytes_to(byte, to, bsize=1024):
         unit = int(unit / bsize)
 
     return unit
+    

--- a/evalai/utils/submissions.py
+++ b/evalai/utils/submissions.py
@@ -79,6 +79,7 @@ def make_submission(challenge_id, phase_id, file, submission_metadata={}):
                 response["id"]
             ),
             bold=True,
+            fg="white"
         )
     )
 
@@ -103,6 +104,7 @@ def pretty_print_my_submissions_data(submissions, start_date, end_date):
             style(
                 "\nSorry, you have not made any submissions to this challenge phase.\n",
                 bold=True,
+                fg="red"
             )
         )
         sys.exit(1)
@@ -132,6 +134,7 @@ def pretty_print_my_submissions_data(submissions, start_date, end_date):
             style(
                 "\nSorry, no submissions were made during this time period.\n",
                 bold=True,
+                fg="red"
             )
         )
         sys.exit(1)
@@ -273,7 +276,7 @@ def display_submission_result(submission_id):
             style(
                 "\nThe Submission is yet to be evaluated.\n",
                 bold=True,
-                fg="yellow",
+                fg="red",
             )
         )
 

--- a/evalai/utils/submissions.py
+++ b/evalai/utils/submissions.py
@@ -291,4 +291,3 @@ def convert_bytes_to(byte, to, bsize=1024):
         unit = int(unit / bsize)
 
     return unit
-    

--- a/evalai/utils/submissions.py
+++ b/evalai/utils/submissions.py
@@ -49,7 +49,7 @@ def make_submission(challenge_id, phase_id, file, submission_metadata={}):
                 )
             )
         else:
-            echo(err)
+            echo(style(err, bold=True, fg="red"))
         if "input_file" in response.json():
             echo(style(response.json()["input_file"][0], fg="red", bold=True))
         sys.exit(1)
@@ -79,6 +79,7 @@ def make_submission(challenge_id, phase_id, file, submission_metadata={}):
                 response["id"]
             ),
             bold=True,
+            fg="white",
         )
     )
 
@@ -103,6 +104,7 @@ def pretty_print_my_submissions_data(submissions, start_date, end_date):
             style(
                 "\nSorry, you have not made any submissions to this challenge phase.\n",
                 bold=True,
+                fg="red"
             )
         )
         sys.exit(1)
@@ -132,6 +134,7 @@ def pretty_print_my_submissions_data(submissions, start_date, end_date):
             style(
                 "\nSorry, no submissions were made during this time period.\n",
                 bold=True,
+                fg="red",
             )
         )
         sys.exit(1)
@@ -166,7 +169,7 @@ def display_my_submission_details(
                 )
             )
         else:
-            echo(err)
+            echo(style(err, bold=True, fg="red"))
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(
@@ -238,7 +241,7 @@ def submission_details_request(submission_id):
                 )
             )
         else:
-            echo(err)
+            echo(style(err, bold=True, fg="red"))
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(
@@ -273,7 +276,7 @@ def display_submission_result(submission_id):
             style(
                 "\nThe Submission is yet to be evaluated.\n",
                 bold=True,
-                fg="yellow",
+                fg="red",
             )
         )
 

--- a/evalai/utils/teams.py
+++ b/evalai/utils/teams.py
@@ -90,7 +90,7 @@ def display_teams(is_host):
     if len(teams) != 0:
         pretty_print_team_data(teams, is_host)
     else:
-        echo("Sorry, no teams found.")
+        echo(style("Sorry, no teams found.", bold=True, fg="red"))
 
 
 def create_team(team_name, team_url, is_host):


### PR DESCRIPTION
Changes
I used the following colors for the CLI output:

red for errors
yellow for questions
white for information responses
green for success messages

I changed it for all output messages in the EvalAI CLI