### PR TITLE
Fix Progress bar for uploading a docker image using CLI 

### DIFF
--- a/evalai/submissions.py
+++ b/evalai/submissions.py
@@ -174,7 +174,7 @@ def push(image, phase, url):
         if line.get("status") in ["Pushing", "Pushed"] and line.get(
             "progress"
         ):
-            print("{id}: {status} {progress}".format(**line))
+            print("{id}: {status} {progress}\r".format(**line), end='', flush=True)
         elif line.get("errorDetail"):
             error = line.get("error")
             notify_user(error, color="red")


### PR DESCRIPTION
I have fixed the progress bar for uploading a docker image using the CLI.

I did this by using "\r" at the end and flush=True to make sure that it refreshes the CLI every time instead of continuing on a new line