### PR TITLE
Fix #205: Add functionality to reset authentication token and logout

### DIFF
--- a/evalai/add_token.py
+++ b/evalai/add_token.py
@@ -16,8 +16,18 @@ def set_token(auth_token):
     Configure EvalAI Token.
     """
     """
-    Invoked by `evalai set_token <your_evalai_auth_token>`.
+    Invoked by `evalai set_token <your_evalai_auth_token>` or `evalai set_token clear_token`.
     """
+    if auth_token == "clear_token":
+        reset_user_auth_token()
+        echo(
+            style(
+                "\nAuthentication Token has been reset successfully.\n",
+                bold=True,
+                fg="green",
+            )
+        )
+        sys.exit()
     if validators.length(auth_token, min=LEN_OF_TOKEN, max=LEN_OF_TOKEN):
         if not os.path.exists(AUTH_TOKEN_DIR):
             os.makedirs(AUTH_TOKEN_DIR)

--- a/evalai/add_token.py
+++ b/evalai/add_token.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import click
 import json
@@ -6,6 +7,7 @@ import validators
 
 from click import echo, style
 
+from evalai.utils.auth import reset_user_auth_token
 from evalai.utils.config import AUTH_TOKEN_DIR, AUTH_TOKEN_PATH, LEN_OF_TOKEN
 
 

--- a/evalai/logout.py
+++ b/evalai/logout.py
@@ -4,6 +4,7 @@ from click import echo, style
 
 from evalai.utils.auth import reset_user_auth_token
 
+
 @click.group(invoke_without_command=True)
 def logout():
     reset_user_auth_token()

--- a/evalai/logout.py
+++ b/evalai/logout.py
@@ -1,0 +1,10 @@
+import click
+
+from click import echo, style
+
+from evalai.utils.auth import reset_user_auth_token
+
+@click.group(invoke_without_command=True)
+def logout():
+    reset_user_auth_token()
+    echo(style("Logout successful", bold=True, fg="green"))

--- a/evalai/main.py
+++ b/evalai/main.py
@@ -9,6 +9,7 @@ from .submissions import submission, push, download_file
 from .teams import teams
 from .get_token import get_token
 from .login import login
+from .logout import logout
 
 
 @click.version_option()
@@ -43,3 +44,4 @@ main.add_command(submission)
 main.add_command(teams)
 main.add_command(get_token)
 main.add_command(login)
+main.add_command(logout)

--- a/evalai/utils/auth.py
+++ b/evalai/utils/auth.py
@@ -107,8 +107,8 @@ def reset_user_auth_token():
     if not os.path.exists(AUTH_TOKEN_PATH):
         echo(
             style(
-                "\nThe authentication token has not been configured. Please use the commands "
-                "`evalai login` or `evalai set_token TOKEN` first to set up the configuration.\n",
+                """\nThe authentication token has not been configured. Please use the commands
+                `evalai login` or `evalai set_token TOKEN` first to set up the configuration.\n""",
                 bold=True,
                 fg="red",
             ),

--- a/evalai/utils/auth.py
+++ b/evalai/utils/auth.py
@@ -98,3 +98,24 @@ def get_host_url():
                 return str(data)
             except (OSError, IOError) as e:
                 echo(style(e, bold=True, fg="red"))
+
+
+def reset_user_auth_token():
+    """
+    Resets the auth token of the user by deleting token.json file
+    """
+    if not os.path.exists(AUTH_TOKEN_PATH):
+        echo(
+            style(
+                "\nThe authentication token has not been configured. Please use the commands "
+                "`evalai login` or `evalai set_token TOKEN` first to set up the configuration.\n",
+                bold=True,
+                fg="red",
+            ),
+        )
+        sys.exit(1)
+    try:
+        os.remove(AUTH_TOKEN_PATH)
+    except (OSError, IOError) as e:
+        echo(style(e, bold=True, fg="red"))
+        sys.exit(1)

--- a/evalai/utils/auth.py
+++ b/evalai/utils/auth.py
@@ -117,5 +117,5 @@ def reset_user_auth_token():
     try:
         os.remove(AUTH_TOKEN_PATH)
     except (OSError, IOError) as e:
-        echo(style(e, bold=True, fg="red"))
+        echo(e)
         sys.exit(1)

--- a/evalai/utils/auth.py
+++ b/evalai/utils/auth.py
@@ -107,8 +107,8 @@ def reset_user_auth_token():
     if not os.path.exists(AUTH_TOKEN_PATH):
         echo(
             style(
-                """\nThe authentication token has not been configured. Please use the commands
-                `evalai login` or `evalai set_token TOKEN` first to set up the configuration.\n""",
+                "\nThe authentication token has not been configured. Please use the commands "
+                "`evalai login` or `evalai set_token TOKEN` first to set up the configuration.\n",
                 bold=True,
                 fg="red",
             ),

--- a/tests/test_auth_utils.py
+++ b/tests/test_auth_utils.py
@@ -47,7 +47,7 @@ class TestResetUserAuthToken(TestCase):
         with mock.patch("sys.stdout", StringIO()) as fake_out:
             with self.assertRaises(SystemExit) as cm:
                 reset_user_auth_token()
-                exit_code = cm.exception.error_code
+            exit_code = cm.exception.error_code
             value = fake_out.getvalue().strip()
 
         self.assertEqual(exit_code, 1)

--- a/tests/test_auth_utils.py
+++ b/tests/test_auth_utils.py
@@ -1,6 +1,8 @@
 import json
 import os
+import random
 import shutil
+import string
 import tempfile
 
 from io import StringIO
@@ -8,6 +10,7 @@ from unittest import mock
 from unittest import TestCase
 
 from evalai.utils.auth import reset_user_auth_token
+
 
 class TestResetUserAuthToken(TestCase):
     def setUp(self):
@@ -35,12 +38,11 @@ class TestResetUserAuthToken(TestCase):
         reset_user_auth_token()
 
         self.assertFalse(os.path.exists(self.token_path))
-        self.assertEqual(value, expected)
 
     def test_reset_user_auth_token_when_token_is_not_configured(self):
         os.remove(self.token_path)
         expected = ("The authentication token has not been configured. Please use the commands ",
-                   "`evalai login` or `evalai set_token TOKEN` first to set up the configuration.")
+                    "`evalai login` or `evalai set_token TOKEN` first to set up the configuration.")
 
         with mock.patch("sys.stdout", StringIO()) as fake_out:
             with self.assertRaises(SystemExit) as cm:

--- a/tests/test_auth_utils.py
+++ b/tests/test_auth_utils.py
@@ -47,7 +47,7 @@ class TestResetUserAuthToken(TestCase):
         with mock.patch("sys.stdout", StringIO()) as fake_out:
             with self.assertRaises(SystemExit) as cm:
                 reset_user_auth_token()
-            exit_code = cm.exception.error_code
+            exit_code = cm.exception.code
             value = fake_out.getvalue().strip()
 
         self.assertEqual(exit_code, 1)
@@ -61,7 +61,7 @@ class TestResetUserAuthToken(TestCase):
         with mock.patch("sys.stdout", StringIO()) as fake_out:
             with self.assertRaises(SystemExit) as cm:
                 reset_user_auth_token()
-                exit_code = cm.exception.error_code
+            exit_code = cm.exception.code
             value = fake_out.getvalue()
 
         self.assertEqual(exit_code, 1)

--- a/tests/test_auth_utils.py
+++ b/tests/test_auth_utils.py
@@ -41,8 +41,10 @@ class TestResetUserAuthToken(TestCase):
 
     def test_reset_user_auth_token_when_token_is_not_configured(self):
         os.remove(self.token_path)
-        expected = """The authentication token has not been configured. Please use the commands 
-                   `evalai login` or `evalai set_token TOKEN` first to set up the configuration."""
+        expected = str(
+            "The authentication token has not been configured. Please use the commands "
+            "`evalai login` or `evalai set_token TOKEN` first to set up the configuration."
+        )
 
         with mock.patch("sys.stdout", StringIO()) as fake_out:
             with self.assertRaises(SystemExit) as cm:

--- a/tests/test_auth_utils.py
+++ b/tests/test_auth_utils.py
@@ -41,8 +41,8 @@ class TestResetUserAuthToken(TestCase):
 
     def test_reset_user_auth_token_when_token_is_not_configured(self):
         os.remove(self.token_path)
-        expected = ("The authentication token has not been configured. Please use the commands ",
-                    "`evalai login` or `evalai set_token TOKEN` first to set up the configuration.")
+        expected = """The authentication token has not been configured. Please use the commands 
+                   `evalai login` or `evalai set_token TOKEN` first to set up the configuration."""
 
         with mock.patch("sys.stdout", StringIO()) as fake_out:
             with self.assertRaises(SystemExit) as cm:
@@ -62,7 +62,7 @@ class TestResetUserAuthToken(TestCase):
             with self.assertRaises(SystemExit) as cm:
                 reset_user_auth_token()
             exit_code = cm.exception.code
-            value = fake_out.getvalue()
+            value = fake_out.getvalue().strip()
 
         self.assertEqual(exit_code, 1)
         self.assertEqual(value, error)

--- a/tests/test_auth_utils.py
+++ b/tests/test_auth_utils.py
@@ -1,0 +1,66 @@
+import json
+import os
+import shutil
+import tempfile
+
+from io import StringIO
+from unittest import mock
+from unittest import TestCase
+
+from evalai.utils.auth import reset_user_auth_token
+
+class TestResetUserAuthToken(TestCase):
+    def setUp(self):
+        self.base_temp_dir = tempfile.mkdtemp()
+        self.token_dir = os.path.join(self.base_temp_dir, ".evalai")
+        self.token_path = os.path.join(self.token_dir, "token.json")
+
+        self.token = "".join(random.choice(string.ascii_lowercase) for _ in range(40))
+        self.token_json = json.dumps({"token": self.token})
+
+        os.makedirs(self.token_dir)
+        with open(self.token_path, "w") as fw:
+            fw.write(self.token_json)
+
+        self.patcher = mock.patch("evalai.utils.auth.AUTH_TOKEN_PATH", self.token_path)
+        self.patcher.start()
+
+    def tearDown(self):
+        self.patcher.stop()
+        if os.path.exists(self.base_temp_dir):
+            shutil.rmtree(self.base_temp_dir)
+
+    def test_reset_user_auth_token_success(self):
+        self.assertTrue(os.path.exists(self.token_path))  # Make sure the path exists already
+        reset_user_auth_token()
+
+        self.assertFalse(os.path.exists(self.token_path))
+        self.assertEqual(value, expected)
+
+    def test_reset_user_auth_token_when_token_is_not_configured(self):
+        os.remove(self.token_path)
+        expected = ("The authentication token has not been configured. Please use the commands ",
+                   "`evalai login` or `evalai set_token TOKEN` first to set up the configuration.")
+
+        with mock.patch("sys.stdout", StringIO()) as fake_out:
+            with self.assertRaises(SystemExit) as cm:
+                reset_user_auth_token()
+                exit_code = cm.exception.error_code
+            value = fake_out.getvalue().strip()
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(value, expected)
+
+    @mock.patch("evalai.utils.auth.os.remove")
+    def test_reset_user_auth_token_when_writing_to_file_fails(self, mock_remove):
+        error = "ExampleError: Example Error Description"
+        mock_remove.side_effect = OSError(error)
+
+        with mock.patch("sys.stdout", StringIO()) as fake_out:
+            with self.assertRaises(SystemExit) as cm:
+                reset_user_auth_token()
+                exit_code = cm.exception.error_code
+            value = fake_out.getvalue()
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(value, error)


### PR DESCRIPTION
#### Objective:
To allow user to easily log out (i.e. reset existing authentication token) from the command line.

#### Changes proposed:
1. Add `reset_user_auth_token` function in auth utils
2. Add tests for `reset_user_auth_token`
3. Add **new command** to logout: 
```
evalai logout
```
4, Add functionality in `set_token` command to clear existing token with:
```
evalai set_token clear_token
```