### PR TITLE
Fix #232: Fix TypeError when using click.style and use red for all errors

### DIFF
--- a/evalai/add_token.py
+++ b/evalai/add_token.py
@@ -27,7 +27,7 @@ def set_token(auth_token):
                 auth_token = json.dumps(auth_token)
                 fw.write(auth_token)
             except (OSError, IOError) as e:
-                echo(e)
+                echo(style(str(e), bold=True, fg="red"))
             echo(
                 style(
                     "Success: Authentication token is successfully set.",

--- a/evalai/get_token.py
+++ b/evalai/get_token.py
@@ -29,4 +29,4 @@ def get_token():
                 tokendata = json.loads(data)
                 echo("Current token is {}".format(tokendata["token"]))
             except (OSError, IOError) as e:
-                echo(e)
+                echo(style(str(e), bold=True, fg="red"))

--- a/evalai/login.py
+++ b/evalai/login.py
@@ -22,7 +22,7 @@ def login(ctx):
             try:
                 json.dump(token, TokenFile)
             except (OSError, IOError) as e:
-                echo(e)
+                echo(style(str(e), bold=True, fg="red"))
     else:
         if not os.path.exists(AUTH_TOKEN_DIR):
             os.makedirs(AUTH_TOKEN_DIR)
@@ -30,6 +30,6 @@ def login(ctx):
             try:
                 json.dump(token, TokenFile)
             except (OSError, IOError) as e:
-                echo(e)
+                echo(style(str(e), bold=True, fg="red"))
 
     echo(style("\nLogged in successfully!", bold=True))

--- a/evalai/set_host.py
+++ b/evalai/set_host.py
@@ -23,7 +23,7 @@ def host(set_host):
                 try:
                     fw.write(set_host)
                 except (OSError, IOError) as e:
-                    echo(e)
+                    echo(style(str(e), bold=True, fg="red"))
                 echo(
                     style(
                         "{} is set as the host url.".format(set_host),
@@ -58,4 +58,4 @@ def host(set_host):
                         )
                     )
                 except (OSError, IOError) as e:
-                    echo(e)
+                    echo(style(str(e), bold=True, fg="red"))

--- a/evalai/submissions.py
+++ b/evalai/submissions.py
@@ -242,7 +242,7 @@ def download_file(url):
             response = requests.get(signed_url, stream=True)
             response.raise_for_status()
         except requests.exceptions.HTTPError as err:
-            echo(err)
+            echo(style(str(err), bold=True, fg="red"))
             sys.exit(1)
         except requests.exceptions.RequestException:
             echo(

--- a/evalai/utils/auth.py
+++ b/evalai/utils/auth.py
@@ -59,7 +59,7 @@ def get_user_auth_token():
             try:
                 data = TokenObj.read()
             except (OSError, IOError) as e:
-                echo(style(e, bold=True, fg="red"))
+                echo(style(str(e), bold=True, fg="red"))
         data = json.loads(data)
         token = data["token"]
         return token
@@ -97,4 +97,4 @@ def get_host_url():
                 data = fr.read()
                 return str(data)
             except (OSError, IOError) as e:
-                echo(style(e, bold=True, fg="red"))
+                echo(style(str(e), bold=True, fg="red"))

--- a/evalai/utils/challenges.py
+++ b/evalai/utils/challenges.py
@@ -65,7 +65,7 @@ def display_challenges(url):
     except requests.exceptions.HTTPError as err:
         if response.status_code == 401:
             validate_token(response.json())
-        echo(err)
+        echo(style(str(err), bold=True, fg="red"))
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(
@@ -116,7 +116,7 @@ def display_ongoing_challenge_list():
     except requests.exceptions.HTTPError as err:
         if response.status_code == 401:
             validate_token(response.json())
-        echo(err)
+        echo(style(str(err), bold=True, fg="red"))
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(
@@ -169,7 +169,7 @@ def get_participant_or_host_teams(url):
     except requests.exceptions.HTTPError as err:
         if response.status_code == 401:
             validate_token(response.json())
-        echo(err)
+        echo(style(str(err), bold=True, fg="red"))
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(
@@ -200,7 +200,7 @@ def get_participant_or_host_team_challenges(url, teams):
         except requests.exceptions.HTTPError as err:
             if response.status_code == 401:
                 validate_token(response.json())
-            echo(err)
+            echo(style(str(err), bold=True, fg="red"))
             sys.exit(1)
         except requests.exceptions.RequestException:
             echo(
@@ -336,7 +336,7 @@ def display_challenge_details(challenge):
                 )
             )
         else:
-            echo(err)
+            echo(style(str(err), bold=True, fg="red"))
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(
@@ -410,7 +410,7 @@ def display_challenge_phase_list(challenge_id):
                 )
             )
         else:
-            echo(err)
+            echo(style(str(err), bold=True, fg="red"))
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(
@@ -515,7 +515,7 @@ def display_challenge_phase_detail(challenge_id, phase_id, is_json):
                 )
             )
         else:
-            echo(err)
+            echo(style(str(err), bold=True, fg="red"))
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(
@@ -583,7 +583,7 @@ def display_challenge_phase_split_list(challenge_id):
                 )
             )
         else:
-            echo(err)
+            echo(style(str(err), bold=True, fg="red"))
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(
@@ -646,7 +646,7 @@ def display_leaderboard(challenge_id, phase_split_id):
                 )
             )
         else:
-            echo(err)
+            echo(style(str(err), bold=True, fg="red"))
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(

--- a/evalai/utils/requests.py
+++ b/evalai/utils/requests.py
@@ -29,7 +29,7 @@ def make_request(path, method, files=None, data=None):
                     )
                 )
             else:
-                echo(err)
+                echo(style(str(err), bold=True, fg="red"))
             sys.exit(1)
         except requests.exceptions.RequestException:
             echo(
@@ -67,7 +67,7 @@ def make_request(path, method, files=None, data=None):
                     )
                 )
             else:
-                echo(err)
+                echo(style(str(err), bold=True, fg="red"))
             sys.exit(1)
         except requests.exceptions.RequestException:
             echo(

--- a/evalai/utils/submissions.py
+++ b/evalai/utils/submissions.py
@@ -49,7 +49,7 @@ def make_submission(challenge_id, phase_id, file, submission_metadata={}):
                 )
             )
         else:
-            echo(err)
+            echo(style(str(err), bold=True, fg="red"))
         if "input_file" in response.json():
             echo(style(response.json()["input_file"][0], fg="red", bold=True))
         sys.exit(1)
@@ -169,7 +169,7 @@ def display_my_submission_details(
                 )
             )
         else:
-            echo(err)
+            echo(style(str(err), bold=True, fg="red"))
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(
@@ -241,7 +241,7 @@ def submission_details_request(submission_id):
                 )
             )
         else:
-            echo(err)
+            echo(style(str(err), bold=True, fg="red"))
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(

--- a/evalai/utils/teams.py
+++ b/evalai/utils/teams.py
@@ -72,7 +72,7 @@ def display_teams(is_host):
                 )
             )
         else:
-            echo(err)
+            echo(style(str(err), bold=True, fg="red"))
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(
@@ -136,7 +136,7 @@ def create_team(team_name, team_url, is_host):
                     )
                 )
         else:
-            echo(err)
+            echo(style(str(err), bold=True, fg="red"))
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(
@@ -200,7 +200,7 @@ def participate_in_a_challenge(challenge_id, participant_team_id):
                 )
             )
         else:
-            echo(err)
+            echo(style(str(err), bold=True, fg="red"))
         sys.exit(1)
     except requests.exceptions.RequestException:
         echo(


### PR DESCRIPTION
Changes proposed:
* Convert errors to strings while using `click.style` on them. (Fixes #232)
* Apply the same to all error messages through the repo (It was missing in several places). This makes the messages consistent throughout the codebase.

@RishabhJain2018 @vkartik97 @Ram81 Please review.