### PR TITLE
Add command to display the stdout.txt data in terminal

### DIFF
--- a/evalai/submissions.py
+++ b/evalai/submissions.py
@@ -17,6 +17,7 @@ from click import echo, style
 from evalai.utils.common import notify_user
 from evalai.utils.requests import make_request
 from evalai.utils.submissions import (
+    display_submission_stdout,
     display_submission_details,
     display_submission_result,
     convert_bytes_to,
@@ -61,6 +62,18 @@ def result(ctx):
     Invoked by `evalai submission SUBMISSION_ID result`.
     """
     display_submission_result(ctx.submission_id)
+
+
+@submission.command()
+@click.pass_obj
+def stdout(ctx):
+    """
+    Display stdout file of the submission
+    """
+    """
+    Invoked by `evalai submission SUBMISSION_ID stdout`.
+    """
+    display_submission_stdout(ctx.submission_id)
 
 
 @click.command()

--- a/evalai/utils/submissions.py
+++ b/evalai/utils/submissions.py
@@ -14,7 +14,6 @@ from evalai.utils.common import (
     convert_UTC_date_to_local,
 )
 
-
 requests.packages.urllib3.disable_warnings()
 
 
@@ -142,7 +141,7 @@ def pretty_print_my_submissions_data(submissions, start_date, end_date):
 
 
 def display_my_submission_details(
-    challenge_id, phase_id, start_date, end_date
+        challenge_id, phase_id, start_date, end_date
 ):
     """
     Function to display the details of a particular submission.
@@ -275,6 +274,23 @@ def display_submission_result(submission_id):
         echo(
             style(
                 "\nThe Submission is yet to be evaluated.\n",
+                bold=True,
+                fg="red",
+            )
+        )
+
+
+def display_submission_stdout(submission_id):
+    """
+    Function to display stdout file of a particular submission
+    """
+    try:
+        response = submission_details_request(submission_id).json()
+        echo(requests.get(response['stdout_file']).text)
+    except requests.exceptions.MissingSchema:
+        echo(
+            style(
+                "\nThe Submission does not have stdout file.\n",
                 bold=True,
                 fg="red",
             )


### PR DESCRIPTION
**Changes**:
- Add a subcommand to show the content of stdout file of the specified submission, invoked by `evalai submission SUBMISSION_ID stdout`.
- Add a helper function of the subcommand.