### PR TITLE
Fixed typos in docstrings

### DIFF
--- a/evalai/utils/submissions.py
+++ b/evalai/utils/submissions.py
@@ -85,7 +85,7 @@ def make_submission(challenge_id, phase_id, file, submission_metadata={}):
 
 def pretty_print_my_submissions_data(submissions, start_date, end_date):
     """
-    Funcion to print the submissions for a particular Challenge.
+    Funcion to print the submissions for a particular challenge.
     """
     table = BeautifulTable(max_width=100)
     attributes = ["id", "participant_team_name", "execution_time", "status"]
@@ -283,7 +283,7 @@ def convert_bytes_to(byte, to, bsize=1024):
     Convert bytes to KB, MB, GB etc.
 
     Arguments:
-        bytes {int} -- The bytes which is to be converted
+        bytes {int} -- The bytes which are to be converted
         to {str} -- To which unit it is to be converted
     """
     units_mapping = {"kb": 1, "mb": 2, "gb": 3, "tb": 4, "pb": 5, "eb": 6}

--- a/evalai/utils/submissions.py
+++ b/evalai/utils/submissions.py
@@ -85,7 +85,7 @@ def make_submission(challenge_id, phase_id, file, submission_metadata={}):
 
 def pretty_print_my_submissions_data(submissions, start_date, end_date):
     """
-    Funcion to print the submissions for a particular challenge.
+    Function to print the submissions for a particular challenge.
     """
     table = BeautifulTable(max_width=100)
     attributes = ["id", "participant_team_name", "execution_time", "status"]


### PR DESCRIPTION
I fixed the typos I could find in the docstrings for EvalAI-cli.

@Ram81 @vkartik97 @RishabhJain2018  @pushkalkatara @Sanji515 @yashdusing

Please take a look