### PR TITLE
Add command to display the stderr data from submission in terminal

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -354,6 +354,19 @@
                 </div>
                 <div class="row">
                     <div class="col-md-12" id="code-label">
+                        <h4 class="code-container-style"><b>View stderr file of a submission with ID 78</b></h4>
+                    </div>
+                </div>
+                <div class="command code-margin">
+                    <div class="label">Run this comand</div>
+                    <div class="text codebg">
+                        <span id="viewSubmissionStderrWithID">evalai submission 78 stderr</span>
+                        <a class="copy-btn" onclick="CopyToClipboard('viewSubmissionStderrWithID')" data-toggle="tooltip" data-placement="top" title="copy to clipboard"><i class="fas fa-copy"></i>
+                        </a>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-md-12" id="code-label">
                         <h4 class="code-container-style"><b>Get all the phase splits of the challenge 1 with phase 4</b></h4>
                     </div>
                 </div>

--- a/evalai/submissions.py
+++ b/evalai/submissions.py
@@ -17,10 +17,10 @@ from click import echo, style
 from evalai.utils.common import notify_user
 from evalai.utils.requests import make_request
 from evalai.utils.submissions import (
+    convert_bytes_to,
     display_submission_details,
     display_submission_result,
     display_submission_stderr,
-    convert_bytes_to,
 )
 from evalai.utils.urls import URLS
 from evalai.utils.config import (

--- a/evalai/submissions.py
+++ b/evalai/submissions.py
@@ -19,6 +19,7 @@ from evalai.utils.requests import make_request
 from evalai.utils.submissions import (
     display_submission_details,
     display_submission_result,
+    display_submission_stderr,
     convert_bytes_to,
 )
 from evalai.utils.urls import URLS
@@ -61,6 +62,18 @@ def result(ctx):
     Invoked by `evalai submission SUBMISSION_ID result`.
     """
     display_submission_result(ctx.submission_id)
+
+
+@submission.command()
+@click.pass_obj
+def stderr(ctx):
+    """
+    Display stderr file of the submission
+    """
+    """
+    Invoked by `evalai submission SUBMISSION_ID stderr`.
+    """
+    display_submission_stderr(ctx.submission_id)
 
 
 @click.command()

--- a/evalai/utils/submissions.py
+++ b/evalai/utils/submissions.py
@@ -281,6 +281,23 @@ def display_submission_result(submission_id):
         )
 
 
+def display_submission_stderr(submission_id):
+    """
+    Function to display stderr file of a particular submission
+    """
+    try:
+        response = submission_details_request(submission_id).json()
+        echo(requests.get(response['stderr_file']).text)
+    except requests.exceptions.MissingSchema:
+        echo(
+            style(
+                "\nThe Submission does not have stderr file.",
+                bold=True,
+                fg="red"
+            )
+        )
+
+
 def convert_bytes_to(byte, to, bsize=1024):
     """
     Convert bytes to KB, MB, GB etc.

--- a/evalai/utils/submissions.py
+++ b/evalai/utils/submissions.py
@@ -287,7 +287,15 @@ def display_submission_stderr(submission_id):
     """
     try:
         response = submission_details_request(submission_id).json()
-        echo(requests.get(response['stderr_file']).text)
+        stderr_content = requests.get(response['stderr_file']).text
+        echo(
+            style(
+                "\nThe content of stderr file:",
+                bold=True,
+                fg="green"
+            )
+        )
+        echo(stderr_content)
     except requests.exceptions.MissingSchema:
         echo(
             style(

--- a/tests/data/submission_response.py
+++ b/tests/data/submission_response.py
@@ -123,6 +123,29 @@ submission_result = """
                     "when_made_public": null
                 }"""
 
+submission_result_with_stdout_and_stderr_file = """
+                {
+                    "challenge_phase": 7,
+                    "created_by": 4,
+                    "execution_time": "None",
+                    "id": 10,
+                    "input_file": "http://testserver/media/submission_files/submission_10/2224fb89-6828-\
+                    47f4-b170-1279290ad900.json",
+                    "is_public": false,
+                    "method_description": null,
+                    "method_name": null,
+                    "participant_team": 3,
+                    "participant_team_name": "Host_83644_Team",
+                    "project_url": null,
+                    "publication_url": null,
+                    "status": "submitted",
+                    "stderr_file": "http://testserver/media/submission_files/submission_10/stderr.txt",
+                    "stdout_file": "http://testserver/media/submission_files/submission_10/stdout.txt",
+                    "submission_result_file": "http://testserver/media/submission_files/submission_10/result.json",
+                    "submitted_at": "2018-06-08T09:24:09.866590Z",
+                    "when_made_public": null
+                }"""
+
 aws_credentials = """
 {
     "success": {

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -129,7 +129,7 @@ class TestDisplaySubmissionStderr(BaseTestClass):
 
     @responses.activate
     def test_display_submission_stderr(self):
-        expected = "Test Submission Stderr File"
+        expected = "The content of stderr file:\nTest Submission Stderr File"
         runner = CliRunner()
         result = runner.invoke(submission, ["10", "stderr"])
         response = result.output.strip()

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -20,6 +20,7 @@ from .base import BaseTestClass
 
 class TestGetSubmissionDetails(BaseTestClass):
     def setup(self):
+
         self.submission = json.loads(submission_response.submission_result)
 
         url = "{}{}"
@@ -315,7 +316,7 @@ class TestMakeSubmission(BaseTestClass):
 
     @responses.activate
     def test_make_submission_for_docker_based_challenge(
-            self, test_make_submission_for_docker_based_challenge_setup
+        self, test_make_submission_for_docker_based_challenge_setup
     ):
         registry_port, image_tag = (
             test_make_submission_for_docker_based_challenge_setup


### PR DESCRIPTION
[**The corresponding GCI task**](https://codein.withgoogle.com/dashboard/task-instances/4965487369256960/)

**Changes**:
- Add a subcommand to show the content of stderr file of the specified submission, invoked by `evalai submission SUBMISSION_ID stderr`.
- Add a helper function of the subcommand.
- Add tests for the helper function.
- Add an example of the subcommand to documentation.

**CC**: @vkartik97 utsav @Ram81 @RishabhJain2018 