### PR TITLE
Take in display_submission_result to result

### DIFF
--- a/evalai/submissions.py
+++ b/evalai/submissions.py
@@ -18,8 +18,8 @@ from evalai.utils.common import notify_user
 from evalai.utils.requests import make_request
 from evalai.utils.submissions import (
     display_submission_details,
-    display_submission_result,
     convert_bytes_to,
+    submission_details_request
 )
 from evalai.utils.urls import URLS
 from evalai.utils.config import (
@@ -60,7 +60,17 @@ def result(ctx):
     """
     Invoked by `evalai submission SUBMISSION_ID result`.
     """
-    display_submission_result(ctx.submission_id)
+    try:
+        response = submission_details_request(ctx.submission_id).json()
+        echo(requests.get(response['submission_result_file']).text)
+    except requests.exceptions.MissingSchema:
+        echo(
+            style(
+                "\nThe Submission is yet to be evaluated.\n",
+                bold=True,
+                fg="red",
+            )
+        )
 
 
 @click.command()

--- a/evalai/utils/submissions.py
+++ b/evalai/utils/submissions.py
@@ -264,23 +264,6 @@ def display_submission_details(submission_id):
     pretty_print_submission_details(response)
 
 
-def display_submission_result(submission_id):
-    """
-    Function to display result of a particular submission
-    """
-    try:
-        response = submission_details_request(submission_id).json()
-        echo(requests.get(response['submission_result_file']).text)
-    except requests.exceptions.MissingSchema:
-        echo(
-            style(
-                "\nThe Submission is yet to be evaluated.\n",
-                bold=True,
-                fg="red",
-            )
-        )
-
-
 def convert_bytes_to(byte, to, bsize=1024):
     """
     Convert bytes to KB, MB, GB etc.


### PR DESCRIPTION
**Changes**:
- Take in the codes of `display_submission_result` to `result`, since `result` only calls `display_submission_result` and that may be redundant.