### PR TITLE
Fix for enhancement#1003: Google Code-in Task to add a command for di…

### DIFF
--- a/evalai/main.py
+++ b/evalai/main.py
@@ -9,6 +9,7 @@ from .submissions import submission, push, download_file
 from .teams import teams
 from .get_token import get_token
 from .login import login
+from .submission_error import submission_error
 
 
 @click.version_option()
@@ -40,6 +41,7 @@ main.add_command(host)
 main.add_command(push)
 main.add_command(set_token)
 main.add_command(submission)
+main.add_command(submission_error)
 main.add_command(teams)
 main.add_command(get_token)
 main.add_command(login)

--- a/evalai/submission_error.py
+++ b/evalai/submission_error.py
@@ -1,0 +1,45 @@
+import os
+
+import base64
+import boto3
+import click
+import docker
+import json
+import requests
+import shutil
+import sys
+import tempfile
+import urllib.parse as urlparse
+import uuid
+
+from click import echo, style
+
+from evalai.utils.common import notify_user
+from evalai.utils.requests import make_request
+from evalai.utils.submissions import (
+    display_submission_stderr,
+    convert_bytes_to,
+)
+from evalai.utils.urls import URLS
+from evalai.utils.config import EVALAI_HOST_URLS, HOST_URL_FILE_PATH
+
+
+class Submission(object):
+
+    def __init__(self, submission_id):
+        self.submission_id = submission_id
+
+
+@click.group(invoke_without_command=True)
+@click.argument("SUBMISSION_ID", type=int)
+@click.pass_context
+def submission_error(ctx, submission_id):
+    """
+    Display submission Error using submission id.
+    """
+    """
+    Invoked by `evalai submission_error SUBMISSION_ID`.
+    """
+    ctx.obj = Submission(submission_id=submission_id)
+    if ctx.invoked_subcommand is None:
+        display_submission_stderr(submission_id)

--- a/evalai/utils/submissions.py
+++ b/evalai/utils/submissions.py
@@ -280,6 +280,28 @@ def display_submission_result(submission_id):
             )
         )
 
+def display_submission_stderr(submission_id):
+    """
+    Function to display stderr file of a particular submission in Terminal output
+    """
+    try:
+        response = submission_details_request(submission_id).json()
+        file_url = requests.get(response['stderr_file']).text
+        with open(file_url, "r") as fr:
+            try:
+                file_contents = fr.read()
+                print (file_contents)
+                fr.close()
+            except (OSError, IOError) as e:
+                echo(e)
+    except requests.exceptions.MissingSchema:
+        echo(
+            style(
+                "\nThe Submission is yet to be evaluated.\n",
+                bold=True,
+                fg="yellow",
+            )
+        )
 
 def convert_bytes_to(byte, to, bsize=1024):
     """


### PR DESCRIPTION
…splaying the text from stderr file generated during submission in terminal

Fix for enhancement#1003: Google Code-in Task to add a command for displaying the text from stderr file generated during submission in terminal.

======

This is for Google Code-in Task. Google Code-in Task to add a command for displaying the text from stderr file generated during submission in terminal. I followed with the same feedback provided by mentor Mr. Kartik Verma from the other task "to display stdout file from the remote host, i.e. where the EvalAI has stored the file. request is to make a API call to EvalAI server to get submission details".

Following are the modifications:

modified/added :
modified: main.py to include the submission_error command
modiifed: evalai/utils/submissions.py to display the stderror message
added: submission_error.py file to support the above functionality.

IMPORTANT NOTES (please read, then delete):

The PR title should start with "Fix #bugnum: " (if applicable), followed by a clear one-line present-tense summary of the changes introduced in the PR. For example: "Fix #bugnum: Introduce the first version of the collection editor.".

Please make sure to mention "#bugnum" somewhere in the description of the PR. This enables Github to link the PR to the corresponding bug.

Please also make sure to follow the [style rules](https://github.com/Cloud-CV/evalai-cli/blob/master/.github/CONTRIBUTING.md).