### PR TITLE
Make import ordering consistent

### DIFF
--- a/evalai/add_token.py
+++ b/evalai/add_token.py
@@ -1,9 +1,8 @@
+import json
 import os
 
 import click
-import json
 import validators
-
 from click import echo, style
 
 from evalai.utils.config import AUTH_TOKEN_DIR, AUTH_TOKEN_PATH, LEN_OF_TOKEN

--- a/evalai/get_token.py
+++ b/evalai/get_token.py
@@ -1,10 +1,10 @@
-import click
+import json
 import os
 
+import click
 from click import echo, style
 
 from evalai.utils.config import AUTH_TOKEN_PATH
-import json
 
 
 @click.group(invoke_without_command=True)


### PR DESCRIPTION
Changes proposed:
* Make import ordering consistent in get_token.py (where `import json` line came after the third-party and `from`-style imports).

* As the ordering was not according to [PEP 8](https://www.python.org/dev/peps/pep-0008/#imports) I made some sample changes to see the differences clearly. 
* In addition to PEP 8, I used [Google's style guide](https://google.github.io/styleguide/pyguide.html#313-imports-formatting) for extended conventions.

The syntax PEP 8 recommends is: 

>  Imports should be grouped in the following order:
>  1. Standard library imports.
>  2. Related third party imports.
>  3. Local application/library specific imports.
>
> You should put a blank line between each group of imports.

So for example,
```python
# standard libraries first, with direct imports first and then "from" imports
import os
import sys
from datetime import datetime

# similarly for third-party imports
import requests
import responses
from bs4 import BeautifulSoup

# then local/specific imports
from evalai.some_app import some_class
from evalai.some_other_app import some_other_class
.
.
.
```
