### PR TITLE
Fix #106: Display error message

### DIFF
--- a/evalai/utils/submissions.py
+++ b/evalai/utils/submissions.py
@@ -48,6 +48,14 @@ def make_submission(challenge_id, phase_id, file, submission_metadata={}):
                     bold=True,
                 )
             )
+        elif response.status_code == 403:
+            echo(
+                style(
+                    "\n" + response.json()["error"] + "\n",
+                    bold=True,
+                    fg="red",
+                )
+            )
         else:
             echo(err)
         if "input_file" in response.json():


### PR DESCRIPTION
Fix #106 

[**The corresponding GCI task**](https://codein.withgoogle.com/dashboard/task-instances/5743334132285440/)

**Changes**:
- Add lines to display an error message when a user submitting to the challenge s/he doesn't participate.

@vkartik97 @pushkalkatara
Could you take a look? Thanks in advance!