### PR TITLE
Add tests for teams

### DIFF
--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -69,6 +69,7 @@ class TestTeams:
         result = runner.invoke(teams, ["--participant", "--host"])
         response = result.output
         assert response == expected
+        assert result.exit_code == 1
 
     @responses.activate
     def test_display_participant_teams_list(self):

--- a/tests/test_teams.py
+++ b/tests/test_teams.py
@@ -60,6 +60,16 @@ class TestTeams:
         self.participant_teams = team_list_data["results"]
         self.host_teams = host_team["results"]
 
+    def test_teams_list_with_both_flags_passed(self):
+        expected = (
+            "Sorry, wrong flag. Please pass either one of the flags "
+            "--participant or --host.\n"
+        )
+        runner = CliRunner()
+        result = runner.invoke(teams, ["--participant", "--host"])
+        response = result.output
+        assert response == expected
+
     @responses.activate
     def test_display_participant_teams_list(self):
         table = BeautifulTable(max_width=200)


### PR DESCRIPTION
**Changes**:
- Add a test case to check the behavior of `teams` command with both flags given.

P.S. This PR is made to offset [the rightful code coverage decrease](https://coveralls.io/builds/28188927/source?filename=evalai%2Fteams.py#L25) at https://github.com/Cloud-CV/evalai-cli/pull/263