### PR TITLE
Add make submission public/private while submitting

### DIFF
--- a/evalai/challenges.py
+++ b/evalai/challenges.py
@@ -2,7 +2,7 @@ import click
 
 from click import style
 
-from evalai.utils.common import Date, upload_file_using_presigned_url
+from evalai.utils.common import Date, notify_user, upload_file_using_presigned_url
 from evalai.utils.challenges import (
     display_all_challenge_list,
     display_future_challenge_list,
@@ -209,10 +209,12 @@ def participate(ctx, team):
 @click.pass_obj
 @click.option("--large", is_flag=True)
 @click.option("--annotation", is_flag=True)
+@click.option("--public", is_flag=True)
+@click.option("--private", is_flag=True)
 @click.option(
     "--file", type=click.File("rb"), required=True, help="File path to the submission or annotation file"
 )
-def submit(ctx, file, annotation, large):
+def submit(ctx, file, annotation, large, public, private):
     """
     For uploading submission files to evalai:
         - Invoked by running 'evalai challenge CHALLENGE phase PHASE submit --file FILE'
@@ -226,30 +228,43 @@ def submit(ctx, file, annotation, large):
         file (str) -- the path of the file to be uploaded
         annotations (boolean) -- flag to denote if file is a test annotation file
         large (boolean) -- flag to denote if submission file is large (if large, presigned urls are used for uploads)
+        public (boolean) -- flag to denote if submission is public
+        private (boolean) -- flag to denote if submission is private
     Returns:
         None
     """
-    if annotation:
-        upload_file_using_presigned_url(ctx.phase_id, file, "annotation")
+    if public and private:
+        message = "\nError: Submission can't be public and private.\nPlease select either --public or --private"
+        notify_user(message, color="red")
     else:
-        submission_metadata = {}
-        if click.confirm("Do you want to include the Submission Details?"):
-            submission_metadata["method_name"] = click.prompt(
-                style("Method Name", fg="yellow"), type=str, default=""
-            )
-            submission_metadata["method_description"] = click.prompt(
-                style("Method Description", fg="yellow"), type=str, default=""
-            )
-            submission_metadata["project_url"] = click.prompt(
-                style("Project URL", fg="yellow"), type=str, default=""
-            )
-            submission_metadata["publication_url"] = click.prompt(
-                style("Publication URL", fg="yellow"), type=str, default=""
-            )
-        if large:
-            upload_file_using_presigned_url(ctx.phase_id, file, "submission", submission_metadata)
+        if annotation:
+            upload_file_using_presigned_url(ctx.phase_id, file, "annotation")
         else:
-            make_submission(ctx.challenge_id, ctx.phase_id, file, submission_metadata)
+            submission_metadata = {}
+            if public:
+                submission_metadata["is_public"] = True
+            elif private:
+                submission_metadata["is_public"] = False
+            else:
+                submission_metadata["is_public"] = None
+            #print(submission_metadata["is_public"])
+            if click.confirm("Do you want to include the Submission Details?"):
+                submission_metadata["method_name"] = click.prompt(
+                    style("Method Name", fg="yellow"), type=str, default=""
+                )
+                submission_metadata["method_description"] = click.prompt(
+                    style("Method Description", fg="yellow"), type=str, default=""
+                )
+                submission_metadata["project_url"] = click.prompt(
+                    style("Project URL", fg="yellow"), type=str, default=""
+                )
+                submission_metadata["publication_url"] = click.prompt(
+                    style("Publication URL", fg="yellow"), type=str, default=""
+                )
+            if large:
+                upload_file_using_presigned_url(ctx.phase_id, file, "submission", submission_metadata)
+            else:
+                make_submission(ctx.challenge_id, ctx.phase_id, file, submission_metadata)
 
 
 challenge.add_command(phase)

--- a/evalai/challenges.py
+++ b/evalai/challenges.py
@@ -247,7 +247,6 @@ def submit(ctx, file, annotation, large, public, private):
                 submission_metadata["is_public"] = False
             else:
                 submission_metadata["is_public"] = None
-            #print(submission_metadata["is_public"])
             if click.confirm("Do you want to include the Submission Details?"):
                 submission_metadata["method_name"] = click.prompt(
                     style("Method Name", fg="yellow"), type=str, default=""


### PR DESCRIPTION
### Description

This PR adds changes to allow making submissions private/public while making a submission using `--public``--private` flags

EvalAI Backend PR -- https://github.com/Cloud-CV/EvalAI/pull/3014