### PR TITLE
Update evalai backend URL domain name

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -420,7 +420,7 @@
                 <div class="command">
                     <div class="label">Run this command</div>
                     <div class="text codebg">
-                        <span id="configureHost">evalai host -sh https://evalapi.cloudcv.org</span>
+                        <span id="configureHost">evalai host -sh https://evalai.cloudcv.org</span>
                         <a class="copy-btn" onclick="CopyToClipboard('configureHost')" data-toggle="tooltip" data-placement="top" title="copy to clipboard"><i class="fas fa-copy"></i>
                         </a>
                     </div>

--- a/evalai/set_host.py
+++ b/evalai/set_host.py
@@ -34,7 +34,7 @@ def host(set_host):
             echo(
                 style(
                     "Sorry, please enter a valid url.\n"
-                    "Example: https://evalapi.cloudcv.org",
+                    "Example: https://evalai.cloudcv.org",
                     bold=True,
                 )
             )
@@ -43,7 +43,7 @@ def host(set_host):
             echo(
                 style(
                     "You haven't configured a Host URL for the CLI.\n"
-                    "The CLI would be using https://evalapi.cloudcv.org as the default url.",
+                    "The CLI would be using https://evalai.cloudcv.org as the default url.",
                     bold=True,
                 )
             )

--- a/evalai/utils/config.py
+++ b/evalai/utils/config.py
@@ -14,7 +14,7 @@ AUTH_TOKEN_DIR = expanduser("~/.evalai/")
 
 AUTH_TOKEN_PATH = os.path.join(AUTH_TOKEN_DIR, AUTH_TOKEN_FILE_NAME)
 
-API_HOST_URL = os.environ.get("EVALAI_API_URL", "https://evalapi.cloudcv.org")
+API_HOST_URL = os.environ.get("EVALAI_API_URL", "https://evalai.cloudcv.org")
 
 EVALAI_ERROR_CODES = [400, 401, 406]
 
@@ -28,4 +28,6 @@ EVALAI_HOST_URLS = [
 
 ENVIRONMENT = os.environ.get("EVALAI_CLI_ENVIRONMENT", "PRODUCTION")
 
-LOCAL_DOCKER_REGISTRY_URI = os.environ.get("EVALAI_LOCAL_DOCKER_REGISTRY_URI", "localhost:5000")
+LOCAL_DOCKER_REGISTRY_URI = os.environ.get(
+    "EVALAI_LOCAL_DOCKER_REGISTRY_URI", "localhost:5000"
+)

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ tests_require = [
 setup(
     name=PROJECT,
     cmdclass={"test": PyTest},
-    version="1.3.3",
+    version="1.3.4",
     description="Use EvalAI through command line interface",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -130,7 +130,7 @@ class TestHostConfig(BaseTestClass):
     def test_get_default_host(self):
         expected = (
             "You haven't configured a Host URL for the CLI.\n"
-            "The CLI would be using https://evalapi.cloudcv.org as the default url.\n"
+            "The CLI would be using https://evalai.cloudcv.org as the default url.\n"
         )
         runner = CliRunner()
         result = runner.invoke(host)
@@ -140,26 +140,26 @@ class TestHostConfig(BaseTestClass):
     def test_set_host_wrong_url(self):
         expected = (
             "Sorry, please enter a valid url.\n"
-            "Example: https://evalapi.cloudcv.org\n"
+            "Example: https://evalai.cloudcv.org\n"
         )
         runner = CliRunner()
-        result = runner.invoke(host, ["-sh", "http:/evalapi.cloudcv"])
+        result = runner.invoke(host, ["-sh", "https:/evalai.cloudcv"])
         assert expected == result.output
         assert result.exit_code == 0
 
     def test_set_host_url(self):
         expected = "{} is set as the host url.\n".format(
-            "https://evalapi.cloudcv.org"
+            "https://evalai.cloudcv.org"
         )
         runner = CliRunner()
-        result = runner.invoke(host, ["-sh", "https://evalapi.cloudcv.org"])
+        result = runner.invoke(host, ["-sh", "https://evalai.cloudcv.org"])
         assert expected == result.output
         assert result.exit_code == 0
 
     def test_set_host_url_and_display(self):
-        expected = "https://evalapi.cloudcv.org is the Host URL of EvalAI.\n"
+        expected = "https://evalai.cloudcv.org is the Host URL of EvalAI.\n"
         runner = CliRunner()
-        runner.invoke(host, ["-sh", "https://evalapi.cloudcv.org"])
+        runner.invoke(host, ["-sh", "https://evalai.cloudcv.org"])
         result = runner.invoke(host)
         assert expected == result.output
         assert result.exit_code == 0
@@ -174,7 +174,7 @@ class TestSetAndLoadHostURL(BaseTestClass):
         responses.add(
             responses.GET,
             url.format(
-                "https://evalapi.cloudcv.org", URLS.challenge_list.value
+                "https://evalai.cloudcv.org", URLS.challenge_list.value
             ),
             json=challenge_data,
             status=200,
@@ -201,13 +201,16 @@ class TestSetAndLoadHostURL(BaseTestClass):
             )
             end_date = convert_UTC_date_to_local(challenge_json["end_date"])
             values.extend([creator, start_date, end_date])
-            table.append_row([colored(values[0], 'white'),
-                              colored(values[1], 'yellow'),
-                              colored(values[2], 'cyan'),
-                              colored(values[3], 'white'),
-                              colored(values[4], 'green'),
-                              colored(values[5], 'red'),
-                              ])
+            table.append_row(
+                [
+                    colored(values[0], "white"),
+                    colored(values[1], "yellow"),
+                    colored(values[2], "cyan"),
+                    colored(values[3], "white"),
+                    colored(values[4], "green"),
+                    colored(values[5], "red"),
+                ]
+            )
         self.output = str(table)
 
     def teardown(self):
@@ -217,7 +220,7 @@ class TestSetAndLoadHostURL(BaseTestClass):
     @responses.activate
     def test_set_and_load_host_url(self):
         runner = CliRunner()
-        result = runner.invoke(host, ["-sh", "https://evalapi.cloudcv.org"])
+        result = runner.invoke(host, ["-sh", "https://evalai.cloudcv.org"])
         result = runner.invoke(challenges)
         response = result.output.strip()
         assert str(response) == self.output


### PR DESCRIPTION
This PR --
- [x] Updates the EvalAI backend URL to `https://evalai.cloudcv.org` after this change https://github.com/Cloud-CV/EvalAI/pull/3028 in EvalAI repository.