### PR TITLE
Fix pyyaml install for coverall

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.6"
 install:
   - pip install -r requirements.txt
-  - pip install coveralls flake8 pytest
+  - pip install PyYAML coveralls flake8 pytest
 script:
   - flake8 ./
   - python setup.py test


### PR DESCRIPTION
### Description

This PR adds `PyYaml` install explicitly to fix coveralls step in travis build. See this issue for reference https://github.com/coveralls-clients/coveralls-python/issues/99.