### PR TITLE
Migrate evalai to eval.ai

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -19,13 +19,13 @@
     	<i onclick="topFunction()" class="fas fa-arrow-up" id="up-arrow"></i>
         <header>
             <div class="logo">
-                <a href="/" style="float: left;"><img style="height: 40px;" src="https://evalai.cloudcv.org/dist/images/evalai-logo-single.png"></a>
+                <a href="/" style="float: left;"><img style="height: 40px;" src="https://eval.ai/dist/images/evalai-logo-single.png"></a>
                 <a href="/" class="header-evalai">EvalAI</a>
             </div>
             <!-- <a class="btn" href="">Docs</a> -->
             <ul class="primary-nav">
                 <li><a class="github fw-300" href="https://evalai-forum.cloudcv.org/" target="_blank">Forum</a></li>
-                <li><a class="support fw-300" href="https://evalai.cloudcv.org/contact" target="_blank">Contact Us</a></li>
+                <li><a class="support fw-300" href="https://eval.ai/contact" target="_blank">Contact Us</a></li>
                 <li><a class="github fw-300" href="https://github.com/Cloud-CV/EvalAI-CLI" target="_blank">GitHub</a></li>
             </ul>
         </header>
@@ -420,7 +420,7 @@
                 <div class="command">
                     <div class="label">Run this command</div>
                     <div class="text codebg">
-                        <span id="configureHost">evalai host -sh https://evalai.cloudcv.org</span>
+                        <span id="configureHost">evalai host -sh https://eval.ai</span>
                         <a class="copy-btn" onclick="CopyToClipboard('configureHost')" data-toggle="tooltip" data-placement="top" title="copy to clipboard"><i class="fas fa-copy"></i>
                         </a>
                     </div>
@@ -445,7 +445,7 @@
         <footer>
             <div class="left">
                 <div class="logo">
-                    <a id="footer-pos" href="https://evalai.cloudcv.org" target="_blank"><img id="img-pos" src="https://evalai.cloudcv.org/dist/images/evalai-logo-single.png"></a>
+                    <a id="footer-pos" href="https://eval.ai" target="_blank"><img id="img-pos" src="https://eval.ai/dist/images/evalai-logo-single.png"></a>
                 </div>  
                 <p id="footer-margin">
                     Maintained by EvalAI Team

--- a/evalai/set_host.py
+++ b/evalai/set_host.py
@@ -34,7 +34,7 @@ def host(set_host):
             echo(
                 style(
                     "Sorry, please enter a valid url.\n"
-                    "Example: https://evalai.cloudcv.org",
+                    "Example: https://eval.ai",
                     bold=True,
                 )
             )
@@ -43,7 +43,7 @@ def host(set_host):
             echo(
                 style(
                     "You haven't configured a Host URL for the CLI.\n"
-                    "The CLI would be using https://evalai.cloudcv.org as the default url.",
+                    "The CLI would be using https://eval.ai as the default url.",
                     bold=True,
                 )
             )

--- a/evalai/utils/config.py
+++ b/evalai/utils/config.py
@@ -14,15 +14,15 @@ AUTH_TOKEN_DIR = expanduser("~/.evalai/")
 
 AUTH_TOKEN_PATH = os.path.join(AUTH_TOKEN_DIR, AUTH_TOKEN_FILE_NAME)
 
-API_HOST_URL = os.environ.get("EVALAI_API_URL", "https://evalai.cloudcv.org")
+API_HOST_URL = os.environ.get("EVALAI_API_URL", "https://eval.ai")
 
 EVALAI_ERROR_CODES = [400, 401, 406]
 
 HOST_URL_FILE_PATH = os.path.join(AUTH_TOKEN_DIR, HOST_URL_FILE_NAME)
 
 EVALAI_HOST_URLS = [
-    "https://evalai.cloudcv.org",
-    "https://evalai-staging.cloudcv.org",
+    "https://eval.ai",
+    "https://staging.eval.ai",
     "http://localhost:8888",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ tests_require = [
 setup(
     name=PROJECT,
     cmdclass={"test": PyTest},
-    version="1.3.4",
+    version="1.3.5",
     description="Use EvalAI through command line interface",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -130,7 +130,7 @@ class TestHostConfig(BaseTestClass):
     def test_get_default_host(self):
         expected = (
             "You haven't configured a Host URL for the CLI.\n"
-            "The CLI would be using https://evalai.cloudcv.org as the default url.\n"
+            "The CLI would be using https://eval.ai as the default url.\n"
         )
         runner = CliRunner()
         result = runner.invoke(host)
@@ -139,8 +139,7 @@ class TestHostConfig(BaseTestClass):
 
     def test_set_host_wrong_url(self):
         expected = (
-            "Sorry, please enter a valid url.\n"
-            "Example: https://evalai.cloudcv.org\n"
+            "Sorry, please enter a valid url.\n" "Example: https://eval.ai\n"
         )
         runner = CliRunner()
         result = runner.invoke(host, ["-sh", "https:/evalai.cloudcv"])
@@ -148,18 +147,16 @@ class TestHostConfig(BaseTestClass):
         assert result.exit_code == 0
 
     def test_set_host_url(self):
-        expected = "{} is set as the host url.\n".format(
-            "https://evalai.cloudcv.org"
-        )
+        expected = "{} is set as the host url.\n".format("https://eval.ai")
         runner = CliRunner()
-        result = runner.invoke(host, ["-sh", "https://evalai.cloudcv.org"])
+        result = runner.invoke(host, ["-sh", "https://eval.ai"])
         assert expected == result.output
         assert result.exit_code == 0
 
     def test_set_host_url_and_display(self):
-        expected = "https://evalai.cloudcv.org is the Host URL of EvalAI.\n"
+        expected = "https://eval.ai is the Host URL of EvalAI.\n"
         runner = CliRunner()
-        runner.invoke(host, ["-sh", "https://evalai.cloudcv.org"])
+        runner.invoke(host, ["-sh", "https://eval.ai"])
         result = runner.invoke(host)
         assert expected == result.output
         assert result.exit_code == 0
@@ -173,9 +170,7 @@ class TestSetAndLoadHostURL(BaseTestClass):
         url = "{}{}"
         responses.add(
             responses.GET,
-            url.format(
-                "https://evalai.cloudcv.org", URLS.challenge_list.value
-            ),
+            url.format("https://eval.ai", URLS.challenge_list.value),
             json=challenge_data,
             status=200,
         )
@@ -220,7 +215,7 @@ class TestSetAndLoadHostURL(BaseTestClass):
     @responses.activate
     def test_set_and_load_host_url(self):
         runner = CliRunner()
-        result = runner.invoke(host, ["-sh", "https://evalai.cloudcv.org"])
+        result = runner.invoke(host, ["-sh", "https://eval.ai"])
         result = runner.invoke(challenges)
         response = result.output.strip()
         assert str(response) == self.output


### PR DESCRIPTION
This PR --
- [x] Migrate all `https://evalai.cloudcv.org` URLs to `https://eval.ai`.