### PR TITLE
Update CLI docs to cli.eval.ai

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-evalai-cli.cloudcv.org
+cli.eval.ai


### PR DESCRIPTION
This PR -- 
- [x] Update CLI docs to point to `https://cli.eval.ai` instead of `https://evalai-cli.cloudcv.org`