### PR TITLE
Ignore .eggs folder while running coveralls coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -11,4 +11,5 @@ exclude_lines =
 omit =
     */python?.?/*
     */tests/*
+    */.eggs/*
     setup.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
   - "3.6"
 install:
   - pip install -r requirements.txt
-  - pip install coverage==4.5.4
   - pip install flake8 pytest PyYAML
   - pip install coveralls
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.6"
 install:
   - pip install -r requirements.txt
+  - pip install coverage==4.5.4
   - pip install flake8 pytest PyYAML
   - pip install coveralls
 script:

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("requirements.txt") as f:
     requirements = f.read().splitlines()
 
 tests_require = [
-    "coverage==4.5.1",
+    "coverage==4.5.4",
     "coveralls==1.3.0",
     "flake8==3.0.4",
     "pytest==3.5.1",


### PR DESCRIPTION
### Description

Ignore `.eggs` folder from coverage check. See this [report](https://coveralls.io/builds/34361516) for reference.