### PR TITLE
[BugFix] EvalAI cli document link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ EvalAI-CLI is designed to extend the functionality of the EvalAI web application
 [![Join the chat at https://gitter.im/Cloud-CV/EvalAI](https://badges.gitter.im/Cloud-CV/EvalAI.svg)](https://gitter.im/Cloud-CV/EvalAI?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/Cloud-CV/evalai-cli.svg?branch=master)](https://travis-ci.org/Cloud-CV/evalai-cli)
 [![Coverage Status](https://coveralls.io/repos/github/Cloud-CV/evalai-cli/badge.svg?branch=master)](https://coveralls.io/github/Cloud-CV/evalai-cli?branch=master)
-[![Documentation Status](https://readthedocs.org/projects/markdown-guide/badge/?version=latest)](https://evalai-cli.cloudcv.org)
+[![Documentation Status](https://readthedocs.org/projects/markdown-guide/badge/?version=latest)](https://cli.eval.ai/)
 
 ## Installation
 
@@ -17,7 +17,7 @@ EvalAI-CLI and its required dependencies can be installed using pip:
 ```sh
 pip install evalai
 ```
-Once EvalAI-CLI is installed, check out the [usage documentation](https://evalai-cli.cloudcv.org/).
+Once EvalAI-CLI is installed, check out the [usage documentation](https://cli.eval.ai/).
 
 ## Contributing Guidelines
 


### PR DESCRIPTION
### Description

This PR fixes 
- [x] Broken EvalAI cli documentation links after migration