### PR TITLE
Update boto3 and tqdm requirement constraints

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 beautifulsoup4==4.7.1
 beautifultable==0.7.0
-boto3==1.9.88
+boto3>=1.9.88
 click==6.7
 docker==3.6.0
 lxml==4.2.1
@@ -8,4 +8,4 @@ python-dateutil==2.7.3
 requests==2.20.0
 validators==0.12.6
 termcolor==1.1.0
-tqdm==4.49.0
+tqdm>=4.49.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ requests==2.20.0
 validators==0.12.6
 termcolor==1.1.0
 tqdm>=4.49.0
-urllib3==1.24.3
+urllib3==1.26.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,7 @@ click==6.7
 docker==3.6.0
 lxml==4.2.1
 python-dateutil==2.7.3
-requests==2.20.0
+requests==2.25.1
 validators==0.12.6
 termcolor==1.1.0
 tqdm>=4.49.0
-urllib3==1.26.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ requests==2.20.0
 validators==0.12.6
 termcolor==1.1.0
 tqdm>=4.49.0
+urllib3==1.24.3

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ tests_require = [
     "pytest-env==0.6.2",
     "responses==0.9.0",
     "pre-commit==1.14.4",
+    "urllib3==1.26.2",
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ tests_require = [
     "pytest-env==0.6.2",
     "responses==0.9.0",
     "pre-commit==1.14.4",
-    "urllib3==1.26.2",
 ]
 
 setup(


### PR DESCRIPTION
### Description

Updates requirement constraints for boto3 and tqdm to `>=1.9.88` and `>=4.49.0`. Fixes #300 