### PR TITLE
Fix deployment dependency issue

### DIFF
--- a/deploy-staging.sh
+++ b/deploy-staging.sh
@@ -1,5 +1,5 @@
 build_and_push() {
-    python3 -m pip install --upgrade setuptools wheel twine
+    python3 -m pip install --upgrade setuptools wheel twine keyring==21.4.0
     python3 setup.py sdist bdist_wheel
     python3 -m twine upload --repository-url https://test.pypi.org/legacy/ dist/* -u ${TEST_PYPI_USERNAME}  -p ${TEST_PYPI_PASSWORD}
 


### PR DESCRIPTION
### Description 

Downgrades keyring version to fix staging deployment issue. Refer [this](https://travis-ci.community/t/cant-deploy-to-pypi-anymore-pkg-resources-contextualversionconflict-importlib-metadata-0-18/10494/6)