### PR TITLE
Increase token length limit to 210

### DIFF
--- a/evalai/utils/config.py
+++ b/evalai/utils/config.py
@@ -4,7 +4,7 @@ import os
 from os.path import expanduser
 
 
-LEN_OF_TOKEN = 40
+LEN_OF_TOKEN = 210
 
 AUTH_TOKEN_FILE_NAME = "token.json"
 


### PR DESCRIPTION
### Description

Set `LEN_OF_TOKEN` to 210 as the jwt token length is 210.