### PR TITLE
Remove token limit checks from set_token command

### DIFF
--- a/evalai/add_token.py
+++ b/evalai/add_token.py
@@ -5,7 +5,7 @@ import click
 import validators
 from click import echo, style
 
-from evalai.utils.config import AUTH_TOKEN_DIR, AUTH_TOKEN_PATH, LEN_OF_TOKEN
+from evalai.utils.config import AUTH_TOKEN_DIR, AUTH_TOKEN_PATH
 
 
 @click.group(invoke_without_command=True)
@@ -17,30 +17,19 @@ def set_token(auth_token):
     """
     Invoked by `evalai set_token <your_evalai_auth_token>`.
     """
-    if validators.length(auth_token, min=LEN_OF_TOKEN, max=LEN_OF_TOKEN):
-        if not os.path.exists(AUTH_TOKEN_DIR):
-            os.makedirs(AUTH_TOKEN_DIR)
-        with open(AUTH_TOKEN_PATH, "w+") as fw:
-            try:
-                auth_token = {"token": "{}".format(auth_token)}  # noqa
-                auth_token = json.dumps(auth_token)
-                fw.write(auth_token)
-            except (OSError, IOError) as e:
-                echo(e)
-            echo(
-                style(
-                    "Success: Authentication token is successfully set.",
-                    bold=True,
-                    fg="green",
-                )
-            )
-    else:
+    if not os.path.exists(AUTH_TOKEN_DIR):
+        os.makedirs(AUTH_TOKEN_DIR)
+    with open(AUTH_TOKEN_PATH, "w+") as fw:
+        try:
+            auth_token = {"token": "{}".format(auth_token)}  # noqa
+            auth_token = json.dumps(auth_token)
+            fw.write(auth_token)
+        except (OSError, IOError) as e:
+            echo(e)
         echo(
             style(
-                "Error: Invalid Length. Enter a valid token of length: {}".format(
-                    LEN_OF_TOKEN
-                ),
+                "Success: Authentication token is successfully set.",
                 bold=True,
-                fg="red"
+                fg="green",
             )
         )

--- a/tests/test_add_token.py
+++ b/tests/test_add_token.py
@@ -14,9 +14,3 @@ class TestSetToken:
         response = result.output.rstrip()
         assert response == expected
 
-    def test_set_token_when_auth_token_is_invalid(self):
-        expected = "Error: Invalid Length. Enter a valid token of length: {}".format(LEN_OF_TOKEN)
-        runner = CliRunner()
-        result = runner.invoke(set_token, [generate_random_string(10)])
-        response = result.output.rstrip()
-        assert response == expected


### PR DESCRIPTION
### Description

This PR removes the token length limit checks from `set_token` command, as jwt tokens can have variable length and adding validations for token size < 7kb would be difficult.