### PR TITLE
Fix #305: Allow users to add submission metadata from cli

### DIFF
--- a/evalai/add_token.py
+++ b/evalai/add_token.py
@@ -2,7 +2,6 @@ import json
 import os
 
 import click
-import validators
 from click import echo, style
 
 from evalai.utils.config import AUTH_TOKEN_DIR, AUTH_TOKEN_PATH

--- a/evalai/add_token.py
+++ b/evalai/add_token.py
@@ -5,7 +5,7 @@ import click
 import validators
 from click import echo, style
 
-from evalai.utils.config import AUTH_TOKEN_DIR, AUTH_TOKEN_PATH, LEN_OF_TOKEN
+from evalai.utils.config import AUTH_TOKEN_DIR, AUTH_TOKEN_PATH
 
 
 @click.group(invoke_without_command=True)
@@ -17,30 +17,19 @@ def set_token(auth_token):
     """
     Invoked by `evalai set_token <your_evalai_auth_token>`.
     """
-    if validators.length(auth_token, min=LEN_OF_TOKEN, max=LEN_OF_TOKEN):
-        if not os.path.exists(AUTH_TOKEN_DIR):
-            os.makedirs(AUTH_TOKEN_DIR)
-        with open(AUTH_TOKEN_PATH, "w+") as fw:
-            try:
-                auth_token = {"token": "{}".format(auth_token)}  # noqa
-                auth_token = json.dumps(auth_token)
-                fw.write(auth_token)
-            except (OSError, IOError) as e:
-                echo(e)
-            echo(
-                style(
-                    "Success: Authentication token is successfully set.",
-                    bold=True,
-                    fg="green",
-                )
-            )
-    else:
+    if not os.path.exists(AUTH_TOKEN_DIR):
+        os.makedirs(AUTH_TOKEN_DIR)
+    with open(AUTH_TOKEN_PATH, "w+") as fw:
+        try:
+            auth_token = {"token": "{}".format(auth_token)}  # noqa
+            auth_token = json.dumps(auth_token)
+            fw.write(auth_token)
+        except (OSError, IOError) as e:
+            echo(e)
         echo(
             style(
-                "Error: Invalid Length. Enter a valid token of length: {}".format(
-                    LEN_OF_TOKEN
-                ),
+                "Success: Authentication token is successfully set.",
                 bold=True,
-                fg="red"
+                fg="green",
             )
         )

--- a/evalai/challenges.py
+++ b/evalai/challenges.py
@@ -326,7 +326,8 @@ def submit(ctx, file, annotation, large, public, private):
                                     break
                                 echo(
                                     "Error: {} is a required field".format(
-                                        attribute_name)
+                                        attribute["name"]
+                                    )
                                 )
                         if attribute_type == "boolean":
                             while True:
@@ -337,13 +338,14 @@ def submit(ctx, file, annotation, large, public, private):
                                     break
                                 echo(
                                     "Error: {} is a required field".format(
-                                        attribute_name)
+                                        attribute["name"]
+                                    )
                                 )
                         if attribute_type == "radio":
                             while True:
                                 value = click.prompt(
                                     style(
-                                        "{}: Choices:{}".format(
+                                        "{}:\nChoices:{}".format(
                                             message, attribute["options"]
                                         ),
                                         fg="yellow",
@@ -355,7 +357,8 @@ def submit(ctx, file, annotation, large, public, private):
                                     break
                                 echo(
                                     "Error: {} is a required field".format(
-                                        attribute_name)
+                                        attribute["name"]
+                                    )
                                 )
                         if attribute_type == "checkbox":
                             optionChosen = True
@@ -363,7 +366,7 @@ def submit(ctx, file, annotation, large, public, private):
                                 value = []
                                 choices = click.prompt(
                                     style(
-                                        "{}: Choices(0 or more separated by comma):{}".format(
+                                        "{}:\nChoices(separated by comma):{}".format(
                                             message, attribute["options"]
                                         ),
                                         fg="yellow",
@@ -383,7 +386,7 @@ def submit(ctx, file, annotation, large, public, private):
                                 if attribute_required and len(choices) == 0:
                                     echo(
                                         "Error: {} is a required field. Please select atleast one option".format(
-                                            attribute_name
+                                            attribute["name"]
                                         )
                                     )
                                     optionChosen = True
@@ -397,7 +400,6 @@ def submit(ctx, file, annotation, large, public, private):
                                         )
                                         optionChosen = True
                                         break
-                            echo("Values chosen: {}".format(value))
                         submission_attribute_metadata.append(
                             {attribute_name: value}
                         )

--- a/evalai/challenges.py
+++ b/evalai/challenges.py
@@ -5,7 +5,11 @@ from click import style
 from click.utils import echo
 
 from evalai.utils.auth import get_host_url
-from evalai.utils.common import Date, notify_user, upload_file_using_presigned_url
+from evalai.utils.common import (
+    Date,
+    notify_user,
+    upload_file_using_presigned_url,
+)
 from evalai.utils.challenges import (
     display_all_challenge_list,
     display_future_challenge_list,
@@ -18,7 +22,10 @@ from evalai.utils.challenges import (
     display_challenge_phase_split_list,
     display_leaderboard,
 )
-from evalai.utils.submissions import display_my_submission_details, get_submission_meta_attributes
+from evalai.utils.submissions import (
+    display_my_submission_details,
+    get_submission_meta_attributes,
+)
 from evalai.utils.teams import participate_in_a_challenge
 from evalai.utils.submissions import make_submission
 from evalai.utils.urls import URLS
@@ -207,13 +214,18 @@ def participate(ctx, team):
     Invoked by running `evalai challenge CHALLENGE participate TEAM`
     """
     terms_and_conditions_page_url = "{}{}".format(
-        get_host_url(), URLS.terms_and_conditions_page.value)
+        get_host_url(), URLS.terms_and_conditions_page.value
+    )
     terms_and_conditions_page_url = terms_and_conditions_page_url.format(
-        ctx.challenge_id)
-    message = "Please refer challenge terms and conditions here: {}" \
-        "\n\nBy agreeing to participate in the challenge, you are agreeing to terms and conditions." \
+        ctx.challenge_id
+    )
+    message = (
+        "Please refer challenge terms and conditions here: {}"
+        "\n\nBy agreeing to participate in the challenge, you are agreeing to terms and conditions."
         "\n\nDo you accept challenge terms and conditions?".format(
-            terms_and_conditions_page_url)
+            terms_and_conditions_page_url
+        )
+    )
     if click.confirm(message):
         participate_in_a_challenge(ctx.challenge_id, team)
     else:
@@ -228,7 +240,10 @@ def participate(ctx, team):
 @click.option("--public", is_flag=True)
 @click.option("--private", is_flag=True)
 @click.option(
-    "--file", type=click.File("rb"), required=True, help="File path to the submission or annotation file"
+    "--file",
+    type=click.File("rb"),
+    required=True,
+    help="File path to the submission or annotation file",
 )
 def submit(ctx, file, annotation, large, public, private):
     """
@@ -268,7 +283,9 @@ def submit(ctx, file, annotation, large, public, private):
                     style("Method Name", fg="yellow"), type=str, default=""
                 )
                 submission_metadata["method_description"] = click.prompt(
-                    style("Method Description", fg="yellow"), type=str, default=""
+                    style("Method Description", fg="yellow"),
+                    type=str,
+                    default="",
                 )
                 submission_metadata["project_url"] = click.prompt(
                     style("Project URL", fg="yellow"), type=str, default=""
@@ -277,53 +294,87 @@ def submit(ctx, file, annotation, large, public, private):
                     style("Publication URL", fg="yellow"), type=str, default=""
                 )
             submission_meta_attributes = get_submission_meta_attributes(
-                ctx.challenge_id, ctx.phase_id)
+                ctx.challenge_id, ctx.phase_id
+            )
             submission_attribute_metadata = []
-            if submission_meta_attributes and len(submission_meta_attributes) > 0:
-                if click.confirm("Do you want to include the Submission Metadata"):
+            if (
+                submission_meta_attributes
+                and len(submission_meta_attributes) > 0
+            ):
+                if click.confirm(
+                    "Do you want to include the Submission Metadata?"
+                ):
                     for attribute in submission_meta_attributes:
-                        typ = attribute["type"]
-                        name = attribute["name"]
-                        desc = attribute["description"]
+                        attribute_type = attribute["type"]
+                        attribute_name = attribute["name"]
+                        attribute_description = attribute["description"]
                         value = None
-                        message = "{} ({})".format(name, desc)
-                        if(typ == "text"):
+                        message = "{} ({})".format(
+                            attribute_name, attribute_description
+                        )
+                        if attribute_type == "text":
                             value = click.prompt(
-                                style(message, fg="yellow"), type=str, default=""
+                                style(message, fg="yellow"),
+                                type=str,
+                                default="",
                             )
-                        if(typ == "boolean"):
+                        if attribute_type == "boolean":
                             value = click.prompt(
                                 style(message, fg="yellow"), type=bool
                             )
-                        if(typ == "radio"):
+                        if attribute_type == "radio":
                             value = click.prompt(
-                                style("{}: Choices:{}".format(message, attribute["options"]), fg="yellow"), type=click.Choice(attribute["options"])
+                                style(
+                                    "{}: Choices:{}".format(
+                                        message, attribute["options"]
+                                    ),
+                                    fg="yellow",
+                                ),
+                                type=click.Choice(attribute["options"]),
                             )
-                        if(typ == "checkbox"):
+                        if attribute_type == "checkbox":
                             optionChosen = True
                             while optionChosen:
                                 value = []
                                 choices = click.prompt(
-                                    style("{}: Choices(0 or more separated by comma):{}".format(message, attribute["options"]), fg="yellow"), type=str
+                                    style(
+                                        "{}: Choices(0 or more separated by comma):{}".format(
+                                            message, attribute["options"]
+                                        ),
+                                        fg="yellow",
+                                    ),
+                                    type=str,
                                 )
-                                choices = choices.strip(' ').split(',')
+                                choices = [
+                                    choice.strip(" ")
+                                    for choice in choices.split(",")
+                                ]
                                 for choice in choices:
-                                    if choice in attribute['options']:
+                                    if choice in attribute["options"]:
                                         value.append(choice)
                                         optionChosen = False
                                     else:
                                         echo(
-                                            "Error: Choose correct value(s) from the given options only")
+                                            "Error: Choose correct value(s) from the given options only"
+                                        )
                                         optionChosen = True
                                         break
                             echo("Values chosen: {}".format(value))
-                        submission_attribute_metadata.append({name: value})
+                        submission_attribute_metadata.append(
+                            {attribute_name: value}
+                        )
             if large:
                 upload_file_using_presigned_url(
-                    ctx.phase_id, file, "submission", submission_metadata)
+                    ctx.phase_id, file, "submission", submission_metadata
+                )
             else:
-                make_submission(ctx.challenge_id, ctx.phase_id,
-                                file, submission_metadata, submission_attribute_metadata)
+                make_submission(
+                    ctx.challenge_id,
+                    ctx.phase_id,
+                    file,
+                    submission_metadata,
+                    submission_attribute_metadata,
+                )
 
 
 challenge.add_command(phase)

--- a/evalai/challenges.py
+++ b/evalai/challenges.py
@@ -361,8 +361,8 @@ def submit(ctx, file, annotation, large, public, private):
                                     )
                                 )
                         if attribute_type == "checkbox":
-                            optionChosen = True
-                            while optionChosen:
+                            option_chosen = True
+                            while option_chosen:
                                 value = []
                                 choices = click.prompt(
                                     style(
@@ -382,23 +382,23 @@ def submit(ctx, file, annotation, large, public, private):
                                     ]
                                 else:
                                     choices = []
-                                    optionChosen = False
+                                    option_chosen = False
                                 if attribute_required and len(choices) == 0:
                                     echo(
                                         "Error: {} is a required field. Please select atleast one option".format(
                                             attribute["name"]
                                         )
                                     )
-                                    optionChosen = True
+                                    option_chosen = True
                                 for choice in choices:
                                     if choice in attribute["options"]:
                                         value.append(choice)
-                                        optionChosen = False
+                                        option_chosen = False
                                     else:
                                         echo(
                                             "Error: Choose correct value(s) from the given options only"
                                         )
-                                        optionChosen = True
+                                        option_chosen = True
                                         break
                         submission_attribute_metadata.append(
                             {attribute_name: value}

--- a/evalai/challenges.py
+++ b/evalai/challenges.py
@@ -308,30 +308,55 @@ def submit(ctx, file, annotation, large, public, private):
                         attribute_type = attribute["type"]
                         attribute_name = attribute["name"]
                         attribute_description = attribute["description"]
+                        attribute_required = attribute.get("required")
+                        if attribute_required:
+                            attribute_name = attribute_name + '*'
                         value = None
                         message = "{} ({})".format(
                             attribute_name, attribute_description
                         )
                         if attribute_type == "text":
-                            value = click.prompt(
-                                style(message, fg="yellow"),
-                                type=str,
-                                default="",
-                            )
+                            while True:
+                                value = click.prompt(
+                                    style(message, fg="yellow"),
+                                    type=str,
+                                    default="",
+                                )
+                                if not attribute_required or value != "":
+                                    break
+                                echo(
+                                    "Error: {} is a required field".format(
+                                        attribute_name)
+                                )
                         if attribute_type == "boolean":
-                            value = click.prompt(
-                                style(message, fg="yellow"), type=bool
-                            )
+                            while True:
+                                value = click.prompt(
+                                    style(message, fg="yellow"), type=bool, default=""
+                                )
+                                if not attribute_required or value != "":
+                                    break
+                                echo(
+                                    "Error: {} is a required field".format(
+                                        attribute_name)
+                                )
                         if attribute_type == "radio":
-                            value = click.prompt(
-                                style(
-                                    "{}: Choices:{}".format(
-                                        message, attribute["options"]
+                            while True:
+                                value = click.prompt(
+                                    style(
+                                        "{}: Choices:{}".format(
+                                            message, attribute["options"]
+                                        ),
+                                        fg="yellow",
                                     ),
-                                    fg="yellow",
-                                ),
-                                type=click.Choice(attribute["options"]),
-                            )
+                                    type=click.Choice(attribute["options"]),
+                                    default=""
+                                )
+                                if not attribute_required or value != "":
+                                    break
+                                echo(
+                                    "Error: {} is a required field".format(
+                                        attribute_name)
+                                )
                         if attribute_type == "checkbox":
                             optionChosen = True
                             while optionChosen:
@@ -344,11 +369,24 @@ def submit(ctx, file, annotation, large, public, private):
                                         fg="yellow",
                                     ),
                                     type=str,
+                                    show_default=False,
+                                    default=""
                                 )
-                                choices = [
-                                    choice.strip(" ")
-                                    for choice in choices.split(",")
-                                ]
+                                if choices != "":
+                                    choices = [
+                                        choice.strip(" ")
+                                        for choice in choices.split(",")
+                                    ]
+                                else:
+                                    choices = []
+                                    optionChosen = False
+                                if attribute_required and len(choices) == 0:
+                                    echo(
+                                        "Error: {} is a required field. Please select atleast one option".format(
+                                            attribute_name
+                                        )
+                                    )
+                                    optionChosen = True
                                 for choice in choices:
                                     if choice in attribute["options"]:
                                         value.append(choice)

--- a/evalai/challenges.py
+++ b/evalai/challenges.py
@@ -2,7 +2,6 @@ import click
 import json
 
 from click import style
-from click.termui import prompt
 from click.utils import echo
 
 from evalai.utils.auth import get_host_url
@@ -313,7 +312,8 @@ def submit(ctx, file, annotation, large, public, private):
                                         value.append(choice)
                                         optionChosen = False
                                     else:
-                                        echo("Error: Choose correct value(s) from the given options only")
+                                        echo(
+                                            "Error: Choose correct value(s) from the given options only")
                                         optionChosen = True
                                         break
                             echo("Values chosen: {}".format(value))

--- a/evalai/challenges.py
+++ b/evalai/challenges.py
@@ -313,7 +313,7 @@ def submit(ctx, file, annotation, large, public, private):
                                         value.append(choice)
                                         optionChosen = False
                                     else:
-                                        echo("Choose correct value(s) from the given options only")
+                                        echo("Error: Choose correct value(s) from the given options only")
                                         optionChosen = True
                                         break
                             echo("Values chosen: {}".format(value))

--- a/evalai/utils/submissions.py
+++ b/evalai/utils/submissions.py
@@ -22,14 +22,19 @@ requests.packages.urllib3.disable_warnings()
 def get_submission_meta_attributes(challenge_id, phase_id):
     """
     Function to get all submission_meta_attributes for a challenge phase
+
+    Parameters:
+    challenge_id (int): id of challenge to which submission is made
+    phase_id (int): id of challenge phase to which submission is made
+
+    Returns:
+    list: list of objects of submission meta attributes
     """
     url = "{}{}".format(get_host_url(), URLS.challenge_phase_detail.value)
     url = url.format(challenge_id, phase_id)
     headers = get_request_header()
     try:
-        response = requests.get(
-            url, headers=headers
-        )
+        response = requests.get(url, headers=headers)
         response.raise_for_status()
     except requests.exceptions.HTTPError as err:
         if response.status_code in EVALAI_ERROR_CODES:
@@ -61,7 +66,13 @@ def get_submission_meta_attributes(challenge_id, phase_id):
     return response["submission_meta_attributes"]
 
 
-def make_submission(challenge_id, phase_id, file, submission_metadata={}, submission_attribute_metadata={}):
+def make_submission(
+    challenge_id,
+    phase_id,
+    file,
+    submission_metadata={},
+    submission_attribute_metadata={},
+):
     """
     Function to submit a file to a challenge
     """
@@ -69,8 +80,10 @@ def make_submission(challenge_id, phase_id, file, submission_metadata={}, submis
     url = url.format(challenge_id, phase_id)
     headers = get_request_header()
     input_file = {"input_file": file}
-    data = {"status": "submitting", "submission_metadata": json.dumps(
-        submission_attribute_metadata)}
+    data = {
+        "status": "submitting",
+        "submission_metadata": json.dumps(submission_attribute_metadata),
+    }
     data = dict(data, **submission_metadata)
     try:
         response = requests.post(
@@ -122,7 +135,7 @@ def make_submission(challenge_id, phase_id, file, submission_metadata={}, submis
                 response["id"]
             ),
             bold=True,
-            fg="white"
+            fg="white",
         )
     )
 
@@ -147,7 +160,7 @@ def pretty_print_my_submissions_data(submissions, start_date, end_date):
             style(
                 "\nSorry, you have not made any submissions to this challenge phase.\n",
                 bold=True,
-                fg="red"
+                fg="red",
             )
         )
         sys.exit(1)
@@ -177,7 +190,7 @@ def pretty_print_my_submissions_data(submissions, start_date, end_date):
             style(
                 "\nSorry, no submissions were made during this time period.\n",
                 bold=True,
-                fg="red"
+                fg="red",
             )
         )
         sys.exit(1)
@@ -313,7 +326,7 @@ def display_submission_result(submission_id):
     """
     try:
         response = submission_details_request(submission_id).json()
-        echo(requests.get(response['submission_result_file']).text)
+        echo(requests.get(response["submission_result_file"]).text)
     except requests.exceptions.MissingSchema:
         echo(
             style(

--- a/evalai/utils/submissions.py
+++ b/evalai/utils/submissions.py
@@ -60,6 +60,7 @@ def get_submission_meta_attributes(challenge_id, phase_id):
     response = response.json()
     return response["submission_meta_attributes"]
 
+
 def make_submission(challenge_id, phase_id, file, submission_metadata={}, submission_attribute_metadata={}):
     """
     Function to submit a file to a challenge
@@ -68,7 +69,8 @@ def make_submission(challenge_id, phase_id, file, submission_metadata={}, submis
     url = url.format(challenge_id, phase_id)
     headers = get_request_header()
     input_file = {"input_file": file}
-    data = {"status": "submitting", "submission_metadata":json.dumps(submission_attribute_metadata)}
+    data = {"status": "submitting", "submission_metadata": json.dumps(
+        submission_attribute_metadata)}
     data = dict(data, **submission_metadata)
     try:
         response = requests.post(

--- a/tests/data/challenge_response.py
+++ b/tests/data/challenge_response.py
@@ -220,19 +220,82 @@ challenge_phase_list = """
 
 challenge_phase_details = """
 {
-    "challenge": 10,
-    "codename": "phase2",
-    "description": "Est nobis consequatur quam sint in nemo distinctio magni. \
-    Eaque a natus laboriosam ipsa molestiae corrupti.",
-    "end_date": "2019-09-25T18:56:42.789372Z",
-    "id": 20,
-    "is_active": false,
-    "is_public": true,
-    "leaderboard_public": true,
-    "max_submissions": 100000,
-    "max_submissions_per_day": 100000,
-    "name": "Philip Phase",
-    "start_date": "2018-08-21T18:56:42.789363Z"
+  "id": 42,
+  "name": "Test Phase",
+  "description": "Test Description",
+  "leaderboard_public": "True",
+  "start_date": "2019-01-01T00:00:00Z",
+  "end_date": "2099-05-24T23:59:59Z",
+  "challenge": 21,
+  "max_submissions_per_day": 5,
+  "max_submissions_per_month": 50,
+  "max_submissions": 50,
+  "is_public": "True",
+  "is_active": "True",
+  "is_submission_public": "True",
+  "codename": "test",
+  "test_annotation": "http://localhost:8000/media/test_annotations/6b95e923-76f7-490e-a2f7-551b354a07b8.pdf",
+  "slug": "random-test-21",
+  "max_concurrent_submissions_allowed": 3,
+  "environment_image": "None",
+  "is_restricted_to_select_one_submission": "False",
+  "submission_meta_attributes": [
+    {
+      "name": "TextAttribute",
+      "type": "text",
+      "required": "True",
+      "description": "Sample"
+    },
+    {
+      "name": "SingleOptionAttribute",
+      "type": "radio",
+      "options": [
+        "A",
+        "B",
+        "C"
+      ],
+      "required": "True",
+      "description": "Sample"
+    },
+    {
+      "name": "MultipleChoiceAttribute",
+      "type": "checkbox",
+      "options": [
+        "alpha",
+        "beta",
+        "gamma"
+      ],
+      "required": "True",
+      "description": "Sample"
+    },
+    {
+      "name": "TrueFalseField",
+      "type": "boolean",
+      "required": "True",
+      "description": "Sample"
+    }
+  ],
+  "is_partial_submission_evaluation_enabled": "False",
+  "config_id": 2,
+  "allowed_submission_file_types": ".json, .zip, .txt, .tsv, .gz, .csv, .h5, .npy",
+  "default_submission_meta_attributes": [
+    {
+      "name": "method_name",
+      "is_visible": "True"
+    },
+    {
+      "name": "method_description",
+      "is_visible": "True"
+    },
+    {
+      "name": "project_url",
+      "is_visible": "True"
+    },
+    {
+      "name": "publication_url",
+      "is_visible": "True"
+    }
+  ]
 }
 """
 

--- a/tests/test_add_token.py
+++ b/tests/test_add_token.py
@@ -11,6 +11,7 @@ class TestSetToken:
         expected = "Success: Authentication token is successfully set."
         runner = CliRunner()
         result = runner.invoke(
-            set_token, [generate_random_string(LEN_OF_TOKEN)])
+            set_token, [generate_random_string(LEN_OF_TOKEN)]
+        )
         response = result.output.rstrip()
         assert response == expected

--- a/tests/test_add_token.py
+++ b/tests/test_add_token.py
@@ -14,9 +14,3 @@ class TestSetToken:
         response = result.output.rstrip()
         assert response == expected
 
-    def test_set_token_when_auth_token_is_invalid(self):
-        expected = "Error: Invalid Length. Enter a valid token of length: {}".format(LEN_OF_TOKEN)
-        runner = CliRunner()
-        result = runner.invoke(set_token, [generate_random_string(10)])
-        response = result.output.rstrip()
-        assert response == expected

--- a/tests/test_add_token.py
+++ b/tests/test_add_token.py
@@ -10,7 +10,7 @@ class TestSetToken:
     def test_set_token(self):
         expected = "Success: Authentication token is successfully set."
         runner = CliRunner()
-        result = runner.invoke(set_token, [generate_random_string(LEN_OF_TOKEN)])
+        result = runner.invoke(
+            set_token, [generate_random_string(LEN_OF_TOKEN)])
         response = result.output.rstrip()
         assert response == expected
-

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -24,6 +24,15 @@ class TestHTTPErrorRequests(BaseTestClass):
 
         responses.add(
             responses.GET,
+            url.format(API_HOST_URL, URLS.challenge_phase_detail.value).format(
+                "1", "2"
+            ),
+            json=json.loads(challenge_response.challenge_phase_details),
+            status=200,
+        )
+
+        responses.add(
+            responses.GET,
             url.format(API_HOST_URL, URLS.challenge_list.value),
             status=404,
         )
@@ -315,11 +324,14 @@ class TestHTTPErrorRequests(BaseTestClass):
             result = runner.invoke(
                 challenge,
                 ["1", "phase", "2", "submit", "--file", "test_file.txt"],
-                input="N",
+                input="N\nN",
             )
             response = result.output.rstrip()
-            expected = "Do you want to include the Submission Details? [y/N]: N\n{}".format(
+            expected = (
+                "Do you want to include the Submission Details? [y/N]: N\n"
+                "Do you want to include the Submission Metadata? [y/N]: N\n{}".format(
                 self.expected.format(url)
+            )
             )
             assert response == expected
 
@@ -376,6 +388,16 @@ class TestSubmissionDetailsWhenObjectDoesNotExist(BaseTestClass):
             status=406,
         )
 
+        # To get Challenge Phase Details
+        url = "{}{}"
+        responses.add(
+            responses.GET,
+            url.format(API_HOST_URL, URLS.challenge_phase_detail.value).format(
+                "1", "2"
+            ),
+            json=json.loads(challenge_response.challenge_phase_details),
+            status=200,
+        )
         self.expected = "Error: Sorry, the object does not exist."
 
     @responses.activate
@@ -400,12 +422,15 @@ class TestSubmissionDetailsWhenObjectDoesNotExist(BaseTestClass):
             result = runner.invoke(
                 challenge,
                 ["1", "phase", "2", "submit", "--file", "test_file.txt"],
-                input="N",
+                input="N\nN",
             )
             response = result.output.strip()
 
-            expected = "Do you want to include the Submission Details? [y/N]: N\n\n{}".format(
+            expected = (
+                "Do you want to include the Submission Details? [y/N]: N\n"
+                "Do you want to include the Submission Metadata? [y/N]: N\n\n{}".format(
                 self.expected
+            )
             )
             expected = "{}\n\n{}".format(
                 expected,

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -330,8 +330,8 @@ class TestHTTPErrorRequests(BaseTestClass):
             expected = (
                 "Do you want to include the Submission Details? [y/N]: N\n"
                 "Do you want to include the Submission Metadata? [y/N]: N\n{}".format(
-                self.expected.format(url)
-            )
+                    self.expected.format(url)
+                )
             )
             assert response == expected
 
@@ -429,8 +429,8 @@ class TestSubmissionDetailsWhenObjectDoesNotExist(BaseTestClass):
             expected = (
                 "Do you want to include the Submission Details? [y/N]: N\n"
                 "Do you want to include the Submission Metadata? [y/N]: N\n\n{}".format(
-                self.expected
-            )
+                    self.expected
+                )
             )
             expected = "{}\n\n{}".format(
                 expected,

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -149,6 +149,17 @@ class TestMakeSubmission(BaseTestClass):
             status=200,
         )
 
+        # To get Challenge Phase Details
+        url = "{}{}"
+        responses.add(
+            responses.GET,
+            url.format(API_HOST_URL, URLS.challenge_phase_detail.value).format(
+                "1", "2"
+            ),
+            json=json.loads(challenge_response.challenge_phase_details),
+            status=200,
+        )
+
         # To get Challenge Phase Details using slug
         url = "{}{}"
         responses.add(
@@ -265,8 +276,11 @@ class TestMakeSubmission(BaseTestClass):
             "Your file {} with the ID {} is successfully submitted.\n\n"
             "You can use `evalai submission {}` to view this submission's status."
         ).format("test_file.txt", "9", "9")
-        expected = "Do you want to include the Submission Details? [y/N]: N\n\n{}".format(
+        expected = (
+            "Do you want to include the Submission Details? [y/N]: N\n"
+            "Do you want to include the Submission Metadata? [y/N]: N\n\n{}".format(
             expected
+        )
         )
         runner = CliRunner()
         with runner.isolated_filesystem():
@@ -276,7 +290,7 @@ class TestMakeSubmission(BaseTestClass):
             result = runner.invoke(
                 challenge,
                 ["1", "phase", "2", "submit", "--file", "test_file.txt"],
-                input="N",
+                input="N\nN",
             )
             assert result.exit_code == 0
             assert result.output.strip() == expected
@@ -291,6 +305,18 @@ class TestMakeSubmission(BaseTestClass):
                 "Test\nProject URL []: Test\nPublication URL []: Test\n"
             ),
         )
+        expected = "{}{}".format(
+            expected,
+            "Do you want to include the Submission Metadata? [y/N]: Y\n",
+        )
+        expected = "{}{}".format(
+            expected,
+            (
+                "TextAttribute* (Sample) []: Test\nSingleOptionAttribute* (Sample):\n"
+                "Choices:['A', 'B', 'C'] []: A\nMultipleChoiceAttribute* (Sample):\n"
+                "Choices(separated by comma):['alpha', 'beta', 'gamma']: alpha\nTrueFalseField* (Sample) []: True\n"
+            ),
+        )
         expected = "{}\n{}".format(
             expected,
             (
@@ -299,7 +325,6 @@ class TestMakeSubmission(BaseTestClass):
                 "submission's status."
             ).format("test_file.txt", "9", "9"),
         )
-
         runner = CliRunner()
         with runner.isolated_filesystem():
             with open("test_file.txt", "w") as f:
@@ -308,7 +333,7 @@ class TestMakeSubmission(BaseTestClass):
             result = runner.invoke(
                 challenge,
                 ["1", "phase", "2", "submit", "--file", "test_file.txt"],
-                input="Y\nTest\nTest\nTest\nTest",
+                input="Y\nTest\nTest\nTest\nTest\nY\nTest\nA\nalpha\nTrue\n",
             )
             assert result.exit_code == 0
             assert result.output.strip() == expected
@@ -370,6 +395,7 @@ class TestMakeSubmission(BaseTestClass):
     def test_make_submission_using_presigned_url(self, request):
         expected = (
             "Do you want to include the Submission Details? [y/N]: N\n"
+            "Do you want to include the Submission Metadata? [y/N]: N\n"
             "Uploading the file...\n\n"
             "Your submission test_file.txt with the id 9 is successfully submitted for evaluation.\n\n"
         )
@@ -381,13 +407,13 @@ class TestMakeSubmission(BaseTestClass):
             result = runner.invoke(
                 challenge,
                 ["1", "phase", "2", "submit", "--file", "test_file.txt", "--large"],
-                input="N"
+                input="N\nN"
             )
             response = result.output
 
             # Remove progress bar from response
             splitted_response = response.split("\n")
-            splitted_response.pop(2)
+            splitted_response.pop(3)
             response = "\n".join(splitted_response)
             assert response == expected
 

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -279,8 +279,8 @@ class TestMakeSubmission(BaseTestClass):
         expected = (
             "Do you want to include the Submission Details? [y/N]: N\n"
             "Do you want to include the Submission Metadata? [y/N]: N\n\n{}".format(
-            expected
-        )
+                expected
+            )
         )
         runner = CliRunner()
         with runner.isolated_filesystem():


### PR DESCRIPTION
Fixes #305 by adding a feature to allow users to provide metadata along with making submissions from the cli. When a user makes a submission, a request is made to the server to check if any submission_meta_attributes are available for the corresponding challenge_phase. If any attributes are found, a prompt would appear asking the user if he/she wants to submit the values. The user can agree to submit these values and then fill in their corresponding choice for each field prompted. Enough instructions and choices are provided to the user through the prompts too