### PR TITLE
fix #313: fix handle error key not found problem in logging errors due to jwt api

### DIFF
--- a/evalai/utils/challenges.py
+++ b/evalai/utils/challenges.py
@@ -323,7 +323,7 @@ def display_challenge_details(challenge):
             validate_token(response.json())
             echo(
                 style(
-                    "\nError: {}".format(response.json()["error"]),
+                    "\nError: {}".format(response.json().get("error", response.json().get("detail"))),
                     fg="red",
                     bold=True,
                 )
@@ -390,7 +390,7 @@ def display_challenge_phase_list(challenge_id):
             validate_token(response.json())
             echo(
                 style(
-                    "\nError: {}".format(response.json()["error"]),
+                    "\nError: {}".format(response.json().get("error", response.json().get("detail"))),
                     fg="red",
                     bold=True,
                 )
@@ -509,7 +509,7 @@ def display_challenge_phase_detail(challenge_id, phase_id, is_json):
                     "\nError: {}\n"
                     "\nUse `evalai challenges` to fetch the active challenges.\n"
                     "\nUse `evalai challenge CHALLENGE phases` to fetch the "
-                    "active phases.\n".format(response.json()["error"]),
+                    "active phases.\n".format(response.json().get("error", response.json().get("detail"))),
                     fg="red",
                     bold=True,
                 )
@@ -577,7 +577,7 @@ def display_challenge_phase_split_list(challenge_id):
                     "\nError: {}\n"
                     "\nUse `evalai challenges` to fetch the active challenges.\n"
                     "\nUse `evalai challenge CHALLENGE phases` to fetch the "
-                    "active phases.\n".format(response.json()["error"]),
+                    "active phases.\n".format(response.json().get("error", response.json().get("detail"))),
                     fg="red",
                     bold=True,
                 )
@@ -640,7 +640,7 @@ def display_leaderboard(challenge_id, phase_split_id):
             validate_token(response.json())
             echo(
                 style(
-                    "Error: {}".format(response.json()["error"]),
+                    "Error: {}".format(response.json().get("error", response.json().get("detail"))),
                     fg="red",
                     bold=True,
                 )

--- a/evalai/utils/common.py
+++ b/evalai/utils/common.py
@@ -225,9 +225,9 @@ def upload_file_using_presigned_url(challenge_phase_pk, file, file_type, submiss
         if response.status_code in EVALAI_ERROR_CODES:
             validate_token(response.json())
             if file_type == "submission":
-                error_message = "\nThere was an error while making the submission: {}\n".format(response.json()["error"])
+                error_message = "\nThere was an error while making the submission: {}\n".format(response.json().get("error", response.json().get("detail")))
             elif file_type == "annotation":
-                error_message = "\nThere was an error while uploading the annotation file: {}".format(response.json()["error"])
+                error_message = "\nThere was an error while uploading the annotation file: {}".format(response.json().get("error", response.json().get("detail")))
             echo(
                 style(
                     error_message,

--- a/evalai/utils/requests.py
+++ b/evalai/utils/requests.py
@@ -23,7 +23,7 @@ def make_request(path, method, files=None, data=None):
                 validate_token(response.json())
                 echo(
                     style(
-                        "\nError: {}\n".format(response.json().get("error")),
+                        "\nError: {}\n".format(response.json().get("error", response.json().get("detail"))),
                         fg="red",
                         bold=True,
                     )
@@ -64,7 +64,7 @@ def make_request(path, method, files=None, data=None):
                         "\nError: {}\n"
                         "\nUse `evalai challenges` to fetch the active challenges.\n"
                         "\nUse `evalai challenge CHALLENGE phases` to fetch the "
-                        "active phases.\n".format(response.json()["error"]),
+                        "active phases.\n".format(response.json().get("error", response.json().get("detail"))),
                         fg="red",
                         bold=True,
                     )

--- a/evalai/utils/submissions.py
+++ b/evalai/utils/submissions.py
@@ -44,7 +44,7 @@ def get_submission_meta_attributes(challenge_id, phase_id):
                     "\nError: {}\n"
                     "\nUse `evalai challenges` to fetch the active challenges.\n"
                     "\nUse `evalai challenge CHALLENGE phases` to fetch the "
-                    "active phases.\n".format(response.json()),
+                    "active phases.\n".format(response.json().get("error", response.json().get("detail"))),
                     fg="red",
                     bold=True,
                 )
@@ -99,7 +99,7 @@ def make_submission(
                     "\nError: {}\n"
                     "\nUse `evalai challenges` to fetch the active challenges.\n"
                     "\nUse `evalai challenge CHALLENGE phases` to fetch the "
-                    "active phases.\n".format(response.json()["error"]),
+                    "active phases.\n".format(response.json().get("error", response.json().get("detail"))),
                     fg="red",
                     bold=True,
                 )
@@ -219,7 +219,7 @@ def display_my_submission_details(
                     "\nError: {}\n"
                     "\nUse `evalai challenges` to fetch the active challenges.\n"
                     "\nUse `evalai challenge CHALLENGE phases` to fetch the "
-                    "active phases.\n".format(response.json()["error"]),
+                    "active phases.\n".format(response.json().get("error", response.json().get("detail"))),
                     fg="red",
                     bold=True,
                 )
@@ -290,7 +290,7 @@ def submission_details_request(submission_id):
                     "\nError: {}\n"
                     "\nUse `evalai challenge CHALLENGE phase PHASE submissions` "
                     "to view your submission.\n".format(
-                        response.json()["error"]
+                        response.json().get("error", response.json().get("detail"))
                     ),
                     fg="red",
                     bold=True,

--- a/evalai/utils/teams.py
+++ b/evalai/utils/teams.py
@@ -66,7 +66,7 @@ def display_teams(is_host):
             validate_token(response.json())
             echo(
                 style(
-                    "Error: {}".format(response.json()["error"]),
+                    "Error: {}".format(response.json().get("error", response.json().get("detail"))),
                     fg="red",
                     bold=True,
                 )
@@ -130,7 +130,7 @@ def create_team(team_name, team_url, is_host):
             else:
                 echo(
                     style(
-                        "Error: {}".format(response.json()["error"]),
+                        "Error: {}".format(response.json().get("error", response.json().get("detail"))),
                         fg="red",
                         bold=True,
                     )
@@ -194,7 +194,7 @@ def participate_in_a_challenge(challenge_id, participant_team_id):
                     "\nError: {}\n"
                     "\nUse `evalai challenges` to fetch the active challenges.\n"
                     "\nUse `evalai teams` to fetch your participant "
-                    "teams.\n".format(response.json()["error"]),
+                    "teams.\n".format(response.json().get("error", response.json().get("detail"))),
                     fg="red",
                     bold=True,
                 )


### PR DESCRIPTION
resolves #313. Now, during logging error, if error key is not present in response.json(), then the  code looks for detail key which contains the error which is returned when error is caused due to the JWT API, and logs the value of detail key if present