### PR TITLE
Fixed Test annotation name mismatch with challenge annotations

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -474,11 +474,11 @@
                     </div>
                 </div>
                 <br id="challenge-annotations">
-                <h3 id="h3-style"><a href="#challenge-annotations" class="sub-heading">Challenge annotations</a></h3>
+                <h3 id="h3-style"><a href="#challenge-annotations" class="sub-heading">Test annotations</a></h3>
                 <hr>
                 <div class="row">
                     <div class="col-md-12" id="code-label">
-                        <h4 class="code-container-style"><b>Upload challenge phase annotations if user is challenge host</b></h4>
+                        <h4 class="code-container-style"><b>Upload test annotations for challenge phase if user is challenge host</b></h4>
                     </div>
                 </div>
                 <div class="command code-margin">
@@ -491,7 +491,7 @@
                 </div>
                 <div class="row">
                     <div class="col-md-12" id="code-label">
-                        <h4 class="code-container-style"><b>Upload challenge phase annotations > 400MB if user is challenge host</b></h4>
+                        <h4 class="code-container-style"><b>Upload test annotations for challenge phase > 400MB if user is challenge host</b></h4>
                     </div>
                 </div>
                 <div class="command code-margin">

--- a/docs/index.html
+++ b/docs/index.html
@@ -473,8 +473,8 @@
                         </a>
                     </div>
                 </div>
-                <br id="challenge-annotations">
-                <h3 id="h3-style"><a href="#challenge-annotations" class="sub-heading">Test annotations</a></h3>
+                <br id="test-annotations">
+                <h3 id="h3-style"><a href="#test-annotations" class="sub-heading">Test annotations</a></h3>
                 <hr>
                 <div class="row">
                     <div class="col-md-12" id="code-label">


### PR DESCRIPTION
In CLI docs,
There are no Challenge annotations, Test annotation is named challenge annotation.
This PR fixes that issue.

![test-annotations](https://user-images.githubusercontent.com/57143358/114657838-74d2b100-9d0e-11eb-89f3-29403b8a1b95.png)