### PR TITLE
Revert "Use Ubuntu 22.04 for Travis Build"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: jammy
 language: python
 sudo: false
 python:


### PR DESCRIPTION
Reverts Cloud-CV/evalai-cli#356