### PR TITLE
Fix: Removes all references to deprecated docker image & code upload methods for submissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,6 @@ Two users will be created by default which are listed below -
     Host User - username: host, password: password
     Participant User - username: participant, password: password
     ```
+
+## Deprecated Methods
+Support for Docker image and code-upload based submissions is currently deprecated.

--- a/docs/index.html
+++ b/docs/index.html
@@ -312,49 +312,10 @@
                     <div class="col-md-12" id="code-label">
                         <h4 class="code-container-style"><b>Make a submission to the Phase 4 of a challenge with ID 1</b></h4>
                     </div>
-                </div>
+                </div>       
                 <div class="row">
                     <div class="col-md-12" id="code-label">
-                        <h4 class="code-container-style"><b>If Challenge 1 is Docker based</b></h4>
-                    </div>
-                </div>
-                <div class="command code-margin">
-                    <div class="label">Run this command</div>
-                    <div class="text codebg">
-                        <span id="makeDockerSubmission">evalai push &lt;image:tag&gt; -p 4 </span>
-                        <a class="copy-btn" onclick="CopyToClipboard('makeDockerSubmission')" data-toggle="tooltip" data-placement="top" title="copy to clipboard"><i class="fas fa-copy"></i>
-                        </a>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col-md-12" id="code-label">
-                        <h4 class="code-container-style"><b>If Challenge 1 is Docker based and you want to make private submission</b></h4>
-                    </div>
-                </div>
-                <div class="command code-margin">
-                    <div class="label">Run this command</div>
-                    <div class="text codebg">
-                        <span id="makePrivateDockerSubmission">evalai push &lt;image:tag&gt; -p 4 --private</span>
-                        <a class="copy-btn" onclick="CopyToClipboard('makePrivateDockerSubmission')" data-toggle="tooltip" data-placement="top" title="copy to clipboard"><i class="fas fa-copy"></i>
-                        </a>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col-md-12" id="code-label">
-                        <h4 class="code-container-style"><b>If Challenge 1 is Docker based and you want to make public submission</b></h4>
-                    </div>
-                </div>
-                <div class="command code-margin">
-                    <div class="label">Run this command</div>
-                    <div class="text codebg">
-                        <span id="makePublicDockerSubmission">evalai push &lt;image:tag&gt; -p 4 --public</span>
-                        <a class="copy-btn" onclick="CopyToClipboard('makePublicDockerSubmission')" data-toggle="tooltip" data-placement="top" title="copy to clipboard"><i class="fas fa-copy"></i>
-                        </a>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col-md-12" id="code-label">
-                        <h4 class="code-container-style"><b>If Challenge 1 is not Docker based</b></h4>
+                        <h4 class="code-container-style"><b>If submission file is &le; 400 MB</b></h4>
                     </div>
                 </div>
                 <div class="command code-margin">
@@ -367,7 +328,7 @@
                 </div>
                 <div class="row">
                     <div class="col-md-12" id="code-label">
-                        <h4 class="code-container-style"><b>If Challenge 1 is not Docker based and submission file is > 400 MB</b></h4>
+                        <h4 class="code-container-style"><b>If submission file is > 400 MB</b></h4>
                     </div>
                 </div>
                 <div class="command code-margin">
@@ -380,7 +341,7 @@
                 </div>
                 <div class="row">
                     <div class="col-md-12" id="code-label">
-                        <h4 class="code-container-style"><b>If Challenge 1 is not Docker based and you want to make private submission</b></h4>
+                        <h4 class="code-container-style"><b>If you want to make private submission</b></h4>
                     </div>
                 </div>
                 <div class="command code-margin">
@@ -393,7 +354,7 @@
                 </div>
                 <div class="row">
                     <div class="col-md-12" id="code-label">
-                        <h4 class="code-container-style"><b>If Challenge 1 is not Docker based and you want to make public submission</b></h4>
+                        <h4 class="code-container-style"><b>If you want to make public submission</b></h4>
                     </div>
                 </div>
                 <div class="command code-margin">


### PR DESCRIPTION
This PR removes all the commands and references regarding docker image based and code upload based challenge submissions. Also, adds a "Deprecated Methods" note in the main README for clarity.

fixes https://github.com/Cloud-CV/EvalAI/issues/4691