### PR TITLE
Add developer notes explaining EvalAI-CLI structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,15 @@ Two users will be created by default which are listed below -
     Host User - username: host, password: password
     Participant User - username: participant, password: password
     ```
+## Developer Notes
+
+This CLI is built using the `click` library.
+
+- The main entry point is defined in `setup.py` via `console_scripts`
+  and maps to `evalai.main:main`.
+- The `main.py` file initializes the CLI and performs checks such as
+  version updates before routing to subcommands.
+- Each CLI command is implemented in its own module inside the `evalai/`
+  directory (for example, `login` is implemented in `evalai/login.py`).
+- Authentication is token-based: the `login` command stores a token
+  locally, and other commands reuse it via shared authentication utilities.


### PR DESCRIPTION
This PR adds a small "Developer Notes" section to the README to help
new contributors understand how the CLI is structured, including
the entry point, command organization, and authentication flow.

This clarification is based on initial contributor experience
and aims to reduce onboarding friction.
