### PR TITLE
Use TestPyPI API token auth instead of username/password.

### DIFF
--- a/.github/CI_CD.md
+++ b/.github/CI_CD.md
@@ -16,8 +16,7 @@ Configure these under **Settings → Secrets and variables → Actions**:
 | Secret | Used for |
 |--------|----------|
 | `CODECOV_TOKEN` | Codecov upload |
-| `TEST_PYPI_USERNAME` | TestPyPI publish on `staging` pushes |
-| `TEST_PYPI_PASSWORD` | TestPyPI publish on `staging` pushes |
+| `TEST_PYPI_API_TOKEN` | TestPyPI publish on `staging` pushes |
 | `PYPI_API_TOKEN` | Production PyPI publish on tag pushes |
 
 ## GitHub environments

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -137,8 +137,8 @@ jobs:
 
       - name: Build and publish package to TestPyPI
         env:
-          TWINE_USERNAME: ${{ secrets.TEST_PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
         run: |
           python -m pip install --upgrade pip setuptools wheel twine
           python setup.py sdist bdist_wheel


### PR DESCRIPTION
Authenticate TestPyPI uploads with __token__ and TEST_PYPI_API_TOKEN, matching the production PyPI publish flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CI/CD documentation to reflect TestPyPI authentication configuration.

* **Chores**
  * Updated TestPyPI publishing workflow to use API token authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->